### PR TITLE
Better defaults for Spirals Nutcracker effect

### DIFF
--- a/Modules/Effect/Nutcracker/NutcrackerData.cs
+++ b/Modules/Effect/Nutcracker/NutcrackerData.cs
@@ -86,9 +86,9 @@ namespace VixenModules.Effect.Nutcracker
 
 		// Spirals
 		[DataMember] public int Spirals_PaletteRepeat = 1;
-		[DataMember] public int Spirals_Direction = 0;
-		[DataMember] public int Spirals_Rotation = 1;
-		[DataMember] public int Spirals_Thickness = 5;
+		[DataMember] public int Spirals_Direction = 1;
+		[DataMember] public int Spirals_Rotation = 20;
+		[DataMember] public int Spirals_Thickness = 60;
 		[DataMember] public bool Spirals_Blend = false;
 		[DataMember] public bool Spirals_3D = false;
 


### PR DESCRIPTION
The original defaults (especially direction=0) did not show any motion when selected.

BTW, I chose this change mostly to see if I understood the process of contributing to Vixen.  I'd appreciate any/all feedback about this.
