### PR TITLE
Correct bug that allows nodes to become abandoned if they are converted ...

### DIFF
--- a/Vixen.System/IO/ObjectVersion.cs
+++ b/Vixen.System/IO/ObjectVersion.cs
@@ -2,7 +2,7 @@
 {
 	internal static class ObjectVersion
 	{
-		public static int SystemConfig = 13;
+		public static int SystemConfig = 14;
 		public static int ModuleStore = 1;
 		public static int SystemContext = 1;
 		public static int Program = 1;

--- a/Vixen.System/IO/Xml/SystemConfig/SystemConfigXElementMigrator.cs
+++ b/Vixen.System/IO/Xml/SystemConfig/SystemConfigXElementMigrator.cs
@@ -23,7 +23,8 @@ namespace Vixen.IO.Xml.SystemConfig
 			                  		new MigrationSegment<XElement>(9, 10, _Version_9_to_10),
 			                  		new MigrationSegment<XElement>(10, 11, _Version_10_to_11),
 			                  		new MigrationSegment<XElement>(11, 12, _Version_11_to_12),
-			                  		new MigrationSegment<XElement>(12, 13, _Version_12_to_13)
+			                  		new MigrationSegment<XElement>(12, 13, _Version_12_to_13),
+									new MigrationSegment<XElement>(13, 14, _Version_13_to_14)
 			                  	};
 		}
 
@@ -247,6 +248,30 @@ namespace Vixen.IO.Xml.SystemConfig
 				disabledControllers.Remove();
 			}
 			content.Add(disabledDevices);
+			return content;
+		}
+
+		private XElement _Version_13_to_14(XElement content)
+		{
+			//Version 14 correct disconnected nodes that where not converted back after being elements.
+			XElement nodes = content.Element("Nodes");
+			if (nodes != null)
+			{
+				XElement channels = content.Element("Channels");
+				foreach(XElement node in nodes.Elements())
+				{
+					if (!node.HasElements && !node.Attributes("channelId").Any() )
+					{
+						Guid channelId = Guid.NewGuid();
+						node.SetAttributeValue("channelId", channelId);
+						XElement channel = new XElement("Channel", 
+							 new XAttribute("id",channelId), 
+							 new XAttribute("name",node.Attribute("name").Value) 
+							 );
+						channels.Add(channel);
+					}
+				}
+			}
 			return content;
 		}
 	}

--- a/Vixen.System/Sys/Managers/NodeManager.cs
+++ b/Vixen.System/Sys/Managers/NodeManager.cs
@@ -92,7 +92,14 @@ namespace Vixen.Sys.Managers
 			}
 			else {
 				node.RemoveFromParent(parent, cleanupIfFloating);
+				//If the parent no longer has children, add a element back to it.
+				if (parent.IsLeaf && parent.Element == null)
+				{
+					parent.Element = new Element(parent.Name);
+					VixenSystem.Elements.AddElement(parent.Element);
+				}
 			}
+
 		}
 
 		public void RenameNode(ElementNode node, string newName)


### PR DESCRIPTION
...from a group back to a element. Update migrator to fix prior broken configs.
