### PR TITLE
VIX-444 - Unable to set change interval to less than 100ms in Alternating Effect

### DIFF
--- a/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
+++ b/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
@@ -3446,17 +3446,16 @@ namespace VixenModules.Editor.TimedSequenceEditor
                 for (int j = 0; j < row.ElementCount; j++)
                 {
                     Element elem = row.ElementAt(j);
-					// BUILD ERROR
-                    //IEffectModuleInstance effect = elem._effectNode.Effect;
-					//if (effect.GetType() == typeof(LipSync))
-					//{
-					//	((LipSync)effect).MakeDirty();
-					//}
+					IEffectModuleInstance effect = elem.EffectNode.Effect;
+					if (effect.GetType() == typeof(LipSync))
+					{
+						((LipSync)effect).MakeDirty();
+					}
 
                 }
             }
-			// BUILD ERROR
-            //TimelineControl.grid.ResetAllElements();
+
+            TimelineControl.grid.RenderAllRows();
         }
 
         private void defaultMapToolStripMenuItem_DropDownOpening(object sender, EventArgs e)


### PR DESCRIPTION
VIX-444 - Unable to set change interval to less than 100ms in Alternating Effect
Modified AlternatingEffectEditorControl.cs - trackBarInterval.Minimum property to have a value of 1 instead of 100

Change was made using the Visual Studio Editor, which causes the diff to show a large number of lines of code changed.  In reality the only change was to trackBarInterval.Minimum which was set to 1 instead of 100.

This change also requires one other change, which was made by Jeff Uchitjil on EditorRevamp branch commit 8bd355512a77866ec3afa42f8e1619e6a8243ecf which is waiting to be pulled also. 
