### PR TITLE
Initialize BottomLeft Point for Matrix Preview

### DIFF
--- a/Modules/Preview/VixenPreview/Shapes/PreviewPixelGrid.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewPixelGrid.cs
@@ -37,6 +37,7 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 			ZoomLevel = zoomLevel;
 			_topLeft = PointToZoomPoint(point1);
 			_bottomRight = new PreviewPoint(_topLeft.X, _topLeft.Y);
+            _bottomLeft = new PreviewPoint(_bottomRight);
 
 			int defaultStringCount = 16;
 			int defaultLightsPerString = 50;


### PR DESCRIPTION
Related to VIX-460.   Null pointer error was being thrown as preview code attempted to manipulate null _bottomLeft point object. 
