### PR TITLE
Fixes crash for draw mode

### DIFF
--- a/Common/Controls/TimeLineControl/Grid_Mouse.cs
+++ b/Common/Controls/TimeLineControl/Grid_Mouse.cs
@@ -323,6 +323,9 @@ namespace Common.Controls.Timeline
 			if (ModifierKeys == Keys.Shift && m_mouseDownElements.Any())
 				gridLocation.X = m_lastGridLocation.X;
 
+			if (ModifierKeys == (Keys.Alt | Keys.Control) && m_mouseDownElements.Any())
+				gridLocation.X = m_lastGridLocation.X;
+
 			if (ModifierKeys == (Keys.Shift | Keys.Alt) && m_mouseDownElements.Any())
 				gridLocation.Y = m_lastGridLocation.Y;
 


### PR DESCRIPTION
If user started drawing below the elements, it would crash because of
null reference to element row.
