### PR TITLE
VIX-509  - Multiple Mark Collection groups would cause Lyric Convert to Crash Vixen

### DIFF
--- a/Modules/App/LipSync/LipSyncTextConvertForm.Designer.cs
+++ b/Modules/App/LipSync/LipSyncTextConvertForm.Designer.cs
@@ -71,6 +71,7 @@
             this.markCollectionCombo.Location = new System.Drawing.Point(83, 20);
             this.markCollectionCombo.Name = "markCollectionCombo";
             this.markCollectionCombo.Size = new System.Drawing.Size(135, 21);
+            this.markCollectionCombo.Sorted = true;
             this.markCollectionCombo.TabIndex = 4;
             this.markCollectionCombo.SelectedIndexChanged += new System.EventHandler(this.markCollectionCombo_SelectedIndexChanged);
             // 
@@ -126,6 +127,7 @@
             this.startOffsetCombo.Location = new System.Drawing.Point(83, 49);
             this.startOffsetCombo.Name = "startOffsetCombo";
             this.startOffsetCombo.Size = new System.Drawing.Size(135, 21);
+            this.startOffsetCombo.Sorted = true;
             this.startOffsetCombo.TabIndex = 10;
             this.startOffsetCombo.DropDown += new System.EventHandler(this.startOffsetCombo_DropDown);
             // 

--- a/Modules/App/LipSync/LipSyncTextConvertForm.cs
+++ b/Modules/App/LipSync/LipSyncTextConvertForm.cs
@@ -16,11 +16,13 @@ namespace VixenModules.App.LipSyncApp
         public event EventHandler<TranslateFailureEventArgs> TranslateFailure = null;
         public static bool Active = false; 
         private int unMarkedPhonemes;
-        
+        private int _lastMarkIndex;
+
         public LipSyncTextConvertForm()
         {
             InitializeComponent();
             unMarkedPhonemes = 0;
+            _lastMarkIndex = -1;
         }
 
         public List<MarkCollection> MarkCollections { get; set; }
@@ -195,6 +197,9 @@ namespace VixenModules.App.LipSyncApp
 
         void populateStartOffsetCombo()
         {
+            int lastIndex = startOffsetCombo.SelectedIndex;
+            int lastCount = startOffsetCombo.Items.Count;
+
             startOffsetCombo.Items.Clear();
             if (markCollectionCombo.SelectedIndex > -1)
             {
@@ -207,20 +212,33 @@ namespace VixenModules.App.LipSyncApp
                         startOffsetCombo.Items.Add(ts);
                     }
                 }
-                startOffsetCombo.SelectedIndex = 
-                    (startOffsetCombo.Items.Count > 0) ? 0 : -1;
+
+                if (startOffsetCombo.Items.Count > 0)
+                {
+                    if (lastIndex < startOffsetCombo.Items.Count)
+                    {
+                        startOffsetCombo.SelectedIndex =
+                            (lastIndex == -1) ? 0 : lastIndex;
+                    }
+                    else
+                    {
+                        startOffsetCombo.SelectedIndex = startOffsetCombo.Items.Count - 1;
+                    }
+                }
             }
         }
 
 
         private void markCollectionCombo_SelectedIndexChanged(object sender, EventArgs e)
         {
-            populateStartOffsetCombo();
-            if (startOffsetCombo.Items.Count > 0)
+            if (_lastMarkIndex != markCollectionCombo.SelectedIndex)
             {
-                startOffsetCombo.SelectedIndex = 0;
+                startOffsetCombo.SelectedIndex = -1;
             }
-            
+
+            populateStartOffsetCombo();
+
+            _lastMarkIndex = markCollectionCombo.SelectedIndex;
         }
 
         private void startOffsetCombo_DropDown(object sender, EventArgs e)
@@ -245,11 +263,10 @@ namespace VixenModules.App.LipSyncApp
             int lastIndex = markCollectionCombo.SelectedIndex;
             int lastCount = markCollectionCombo.Items.Count;
 
-            MarkCollections.Sort();
             markCollectionCombo.Items.Clear();
             foreach (MarkCollection mc in MarkCollections)
             {
-                if (mc.Name != null)
+                if ((mc.Name != null) && (mc.Marks.Count != 0))
                 {
                     markCollectionCombo.Items.Add(mc.Name);
                 }
@@ -261,8 +278,14 @@ namespace VixenModules.App.LipSyncApp
             {
                 if (markCollectionCombo.Items.Count == lastCount) 
                 {
-                    markCollectionCombo.SelectedIndex = 
-                        (lastIndex == -1) ? 0 : lastIndex;
+                    if (lastIndex == -1)
+                    {
+                        markCollectionCombo.SelectedIndex = 0;
+                    }
+                    else
+                    {
+                        markCollectionCombo.SelectedIndex = lastIndex;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
In instance of where there was more than one Mark collection defind, it would cause Vixen3 to crash whenever the Lipsync Lyric converter was pulled up.  This was due to the mark collections being improperly sorted. 
