### PR TITLE
Corrects gradient editor caption and fixes crash.

### DIFF
--- a/Modules/App/ColorGradients/ColorGradientEditor.cs
+++ b/Modules/App/ColorGradients/ColorGradientEditor.cs
@@ -111,7 +111,7 @@ namespace VixenModules.App.ColorGradients
 				buttonUnlink.Enabled = item.IsLibraryReference;
 				buttonEditLibraryItem.Enabled = item.IsLibraryReference;
 
-				Text = "Curve Editor";
+				Text = @"Color Gradient Editor";
 			}
 
 			gradientEditPanel.Invalidate();

--- a/Modules/App/ColorGradients/GradientEdit.cs
+++ b/Modules/App/ColorGradients/GradientEdit.cs
@@ -400,6 +400,14 @@ namespace VixenModules.App.ColorGradients
 
 		protected override void OnMouseDoubleClick(MouseEventArgs e)
 		{
+			//We need to make sure we double clicked on a fader and not just the control.
+			Point pt = Point.Empty;
+			bool foc;
+			if (!GetFadersUnderMouse(e.Location, ref pt, out foc).Any())
+			{
+				return;
+			}
+
 			if (Selection != null && !ReadOnly)
 				RaiseSelectionDoubleClicked();
 			base.OnMouseDoubleClick(e);


### PR DESCRIPTION
Makes sure that double click action is on a fader, not just the control.
Would cause crash due to no active fader if you double clicked anywhere in the
control except a fader.

For VIX-558 561
