### PR TITLE
Save Lipsync Map data when Map Editor is closed instead of at shutdown. (Lipsync_Map_Save)

### DIFF
--- a/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
+++ b/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
@@ -4307,7 +4307,8 @@ namespace VixenModules.Editor.TimedSequenceEditor
                 mapSelector.Changed = false;
                 sequenceModified();
                 resetLipSyncNodes();
-	}
+                VixenSystem.SaveSystemConfig();
+	        }
         }
 
         private void setDefaultMap_Click(object sender,EventArgs e)


### PR DESCRIPTION
Lip sync map now saves when the editor is closed vs when the Admin dialog box is closed
