### PR TITLE
VIX-591 - Corrected FPP export bug

### DIFF
--- a/Vixen.System/Export/FSEQWriter.cs
+++ b/Vixen.System/Export/FSEQWriter.cs
@@ -107,6 +107,7 @@ namespace Vixen.Export
 
         public void OpenSession(SequenceSessionData data)
         {
+            this.SeqPeriodTime = data.PeriodMS;
             OpenSession(data.OutFileName, data.NumPeriods, data.ChannelNames.Count());
         }
 


### PR DESCRIPTION
Bug would occur when export resolutions other than 50ms where utilized.
