### PR TITLE
VIX-602 - Mark Manager Crash

### DIFF
--- a/Modules/Editor/TimedSequenceEditor/MarkManager.cs
+++ b/Modules/Editor/TimedSequenceEditor/MarkManager.cs
@@ -722,17 +722,21 @@ namespace VixenModules.Editor.TimedSequenceEditor
 			}
 			else {
 				//detect if sequence reached the end
-				if (!_timedSequenceEditorForm.positionHasValue) {
+				if ((!_timedSequenceEditorForm.positionHasValue) || 
+					(_timingSource.Position.TotalMilliseconds > _timedSequenceEditorForm.Sequence.Length.TotalMilliseconds)) 
+				{
 					sequenceStop();
 					updatePositionControls(TimeSpan.Zero); //reset to beginning
 					updateControlsForStopped();
 				}
-				else {
+				else 
+				{
 					textBoxPosition.Text = _timingSource.Position.ToString();
 					updatePositionControls(_timingSource.Position);
 
 					//handle playback mode
-					if (_displayedCollection != null && radioButtonPlayback.Checked) {
+					if (_displayedCollection != null && radioButtonPlayback.Checked) 
+					{
 						handlePlaybackModeTick();
 					}
 				}


### PR DESCRIPTION
Added Check in Mark Manager to stop playback if position of playback ever exceeds the sequence length.  Thread timing could cause instances where playback position might equal a value > then the sequence length at the end of playback
