### PR TITLE
Adds an option to use the selection box as CAD Style

### DIFF
--- a/Common/Controls/TimeLineControl/Grid.cs
+++ b/Common/Controls/TimeLineControl/Grid.cs
@@ -50,6 +50,7 @@ namespace Common.Controls.Timeline
 		public bool isGradientDrop { get; set; }
 		private MouseButtons MouseButtonDown;
 		public string alignmentHelperWarning = @"Too many effects selected on the same row for this action.\nMax selected effects per row for this action is 4";
+		public bool aCadStyleSelectionBox { get; set; }
 
 		#region Initialization
 
@@ -1191,7 +1192,10 @@ namespace Common.Controls.Timeline
 			TimeSpan selEnd = pixelsToTime(SelectedArea.Right);
 			int selTop = SelectedArea.Top;
 			int selBottom = selTop + SelectedArea.Height;
+			string moveDirection = (SelectedArea.Left < mouseDownGridLocation.X || !aCadStyleSelectionBox) ? "Left" : "Right";
 
+			SelectionBorder = (moveDirection == "Right") ? Color.Green : Color.Blue;
+			
 			// deselect all elements in the grid first, then only select the ones in the box.
 			ClearSelectedElements();
 
@@ -1225,11 +1229,35 @@ namespace Common.Controls.Timeline
 						int elemBottom = elemTop + elem.DisplayHeight;
 						if (DragBoxFilterEnabled)
 						{
-							elem.Selected = (ShiftPressed && tempSelectedElements.Contains(elem) ? true : ((elem.StartTime < selEnd && elem.EndTime > selStart) && (elemTop < selBottom && elemBottom > selTop) && DragBoxFilterTypes.Contains(elem.EffectNode.Effect.TypeId)));
+							if (moveDirection == "Left")
+							{
+								elem.Selected = (ShiftPressed && tempSelectedElements.Contains(elem)
+									? true
+									: ((elem.StartTime < selEnd && elem.EndTime > selStart) && (elemTop < selBottom && elemBottom > selTop) &&
+									   DragBoxFilterTypes.Contains(elem.EffectNode.Effect.TypeId)));
+							}
+							else
+							{
+								elem.Selected = (ShiftPressed && tempSelectedElements.Contains(elem)
+									? true
+									: ((elem.StartTime > selStart && elem.EndTime < selEnd) && (elemTop > selTop && elemBottom < selBottom) &&
+									   DragBoxFilterTypes.Contains(elem.EffectNode.Effect.TypeId)));
+							}
 						}
 						else
 						{
-							elem.Selected = (ShiftPressed && tempSelectedElements.Contains(elem) ? true : ((elem.StartTime < selEnd && elem.EndTime > selStart) && (elemTop < selBottom && elemBottom > selTop)));
+							if (moveDirection == "Left")
+							{
+								elem.Selected = (ShiftPressed && tempSelectedElements.Contains(elem)
+									? true
+									: ((elem.StartTime < selEnd && elem.EndTime > selStart) && (elemTop < selBottom && elemBottom > selTop)));
+							}
+							else
+							{
+								elem.Selected = (ShiftPressed && tempSelectedElements.Contains(elem)
+									? true
+									: ((elem.StartTime > selStart && elem.EndTime < selEnd) && (elemTop > selTop && elemBottom < selBottom)));
+							}
 						}
 					}
 

--- a/Common/Controls/TimeLineControl/Grid_Mouse.cs
+++ b/Common/Controls/TimeLineControl/Grid_Mouse.cs
@@ -14,6 +14,7 @@ namespace Common.Controls.Timeline
 		public bool _beginEffectDraw;
 		private TimeSpan effectDrawMouseDownTime;
 		private TimeSpan effectDrawMouseUpTime;
+		private Point mouseDownGridLocation, mouseUpGridLocation;
 
 		#region General Mouse Event-Related
 
@@ -35,7 +36,7 @@ namespace Common.Controls.Timeline
 		{
 			base.OnMouseDown(e);
 
-			Point gridLocation = translateLocation(e.Location);
+			Point gridLocation = mouseDownGridLocation = translateLocation(e.Location);
 
 			m_lastGridLocation = gridLocation; //new
 			m_mouseDownElementRow = rowAt(gridLocation);
@@ -145,7 +146,7 @@ namespace Common.Controls.Timeline
 		{
 			base.OnMouseUp(e);
 
-			Point gridLocation = translateLocation(e.Location);
+			Point gridLocation = mouseUpGridLocation = translateLocation(e.Location);
 
 			if (e.Button == MouseButtons.Middle && _beginEffectDraw)
 			{

--- a/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.Designer.cs
+++ b/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.Designer.cs
@@ -18,164 +18,165 @@ namespace VixenModules.Editor.TimedSequenceEditor
 		/// </summary>
 		private void InitializeComponent()
 		{
-            this.components = new System.ComponentModel.Container();
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(TimedSequenceEditorForm));
-            WeifenLuo.WinFormsUI.Docking.DockPanelSkin dockPanelSkin1 = new WeifenLuo.WinFormsUI.Docking.DockPanelSkin();
-            WeifenLuo.WinFormsUI.Docking.AutoHideStripSkin autoHideStripSkin1 = new WeifenLuo.WinFormsUI.Docking.AutoHideStripSkin();
-            WeifenLuo.WinFormsUI.Docking.DockPanelGradient dockPanelGradient1 = new WeifenLuo.WinFormsUI.Docking.DockPanelGradient();
-            WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient1 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
-            WeifenLuo.WinFormsUI.Docking.DockPaneStripSkin dockPaneStripSkin1 = new WeifenLuo.WinFormsUI.Docking.DockPaneStripSkin();
-            WeifenLuo.WinFormsUI.Docking.DockPaneStripGradient dockPaneStripGradient1 = new WeifenLuo.WinFormsUI.Docking.DockPaneStripGradient();
-            WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient2 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
-            WeifenLuo.WinFormsUI.Docking.DockPanelGradient dockPanelGradient2 = new WeifenLuo.WinFormsUI.Docking.DockPanelGradient();
-            WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient3 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
-            WeifenLuo.WinFormsUI.Docking.DockPaneStripToolWindowGradient dockPaneStripToolWindowGradient1 = new WeifenLuo.WinFormsUI.Docking.DockPaneStripToolWindowGradient();
-            WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient4 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
-            WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient5 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
-            WeifenLuo.WinFormsUI.Docking.DockPanelGradient dockPanelGradient3 = new WeifenLuo.WinFormsUI.Docking.DockPanelGradient();
-            WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient6 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
-            WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient7 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
-            this.toolStripOperations = new Common.Controls.ToolStripEx();
-            this.toolStripButton_Start = new System.Windows.Forms.ToolStripButton();
-            this.toolStripButton_Play = new System.Windows.Forms.ToolStripButton();
-            this.toolStripButton_Stop = new System.Windows.Forms.ToolStripButton();
-            this.toolStripButton_Pause = new System.Windows.Forms.ToolStripButton();
-            this.toolStripButton_End = new System.Windows.Forms.ToolStripButton();
-            this.toolStripButton_Loop = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
-            this.undoButton = new Common.Controls.UndoButton();
-            this.redoButton = new Common.Controls.UndoButton();
-            this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripButton_Cut = new System.Windows.Forms.ToolStripButton();
-            this.toolStripButton_Copy = new System.Windows.Forms.ToolStripButton();
-            this.toolStripButton_Paste = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripButton_AssociateAudio = new System.Windows.Forms.ToolStripButton();
-            this.toolStripButton_MarkManager = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripButton_ZoomTimeIn = new System.Windows.Forms.ToolStripButton();
-            this.toolStripButton_ZoomTimeOut = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripButton_DrawMode = new System.Windows.Forms.ToolStripButton();
-            this.toolStripButton_SelectionMode = new System.Windows.Forms.ToolStripButton();
-            this.toolStripButton_SnapTo = new System.Windows.Forms.ToolStripButton();
-            this.toolStripDropDownButton_SnapToStrength = new System.Windows.Forms.ToolStripDropDownButton();
-            this.toolStripMenuItem_SnapStrength_1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem_SnapStrength_2 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem_SnapStrength_3 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem_SnapStrength_4 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripButton_DragBoxFilter = new System.Windows.Forms.ToolStripButton();
-            this.toolStripDropDownButton_DragBoxFilter = new System.Windows.Forms.ToolStripDropDownButton();
-            this.toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripLabel_TimingSpeedLabel = new System.Windows.Forms.ToolStripLabel();
-            this.toolStripLabel_TimingSpeed = new System.Windows.Forms.ToolStripLabel();
-            this.toolStripButton_IncreaseTimingSpeed = new System.Windows.Forms.ToolStripButton();
-            this.toolStripButton_DecreaseTimingSpeed = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator12 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripLabel3 = new System.Windows.Forms.ToolStripLabel();
-            this.cboAudioDevices = new System.Windows.Forms.ToolStripComboBox();
-            this.menuStrip = new Common.Controls.MenuStripEx();
-            this.sequenceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem_Save = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem_SaveAs = new System.Windows.Forms.ToolStripMenuItem();
-            this.autoSaveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator15 = new System.Windows.Forms.ToolStripSeparator();
-            this.playbackToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.playToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.pauseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.stopToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem_Loop = new System.Windows.Forms.ToolStripMenuItem();
-            this.playOptionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.delayOffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.delay5SecondsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.delay10SecondsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.delay20SecondsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.delay30SecondsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.delay60SecondsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator16 = new System.Windows.Forms.ToolStripSeparator();
-            this.exportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripMenuItem_Close = new System.Windows.Forms.ToolStripMenuItem();
-            this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.addEffectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem_EditEffect = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripMenuItem_Cut = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem_Copy = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem_Paste = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-            this.selectAllElementsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem_deleteElements = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripMenuItem_SnapTo = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem_ResizeIndicator = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem_RIColor_Blue = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem_RIColor_Yellow = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem_RIColor_Green = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem_RIColor_White = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem_RIColor_Red = new System.Windows.Forms.ToolStripMenuItem();
-            this.viewToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem_zoomTimeIn = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem_zoomTimeOut = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem_zoomRowsIn = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem_zoomRowsOut = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
-            this.effectWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.markWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem_associateAudio = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem_removeAudio = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem_MarkManager = new System.Windows.Forms.ToolStripMenuItem();
-            this.modifySequenceLengthToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.curveEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.colorGradientEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.ColorCollectionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.lipSyncMappingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.defaultMapToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.phonemeMappingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.changeMapToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.lyricConverterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.papagayoImportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.bulkEffectMoveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.helpDocumentationToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.timerPlaying = new System.Windows.Forms.Timer(this.components);
-            this.statusStrip = new System.Windows.Forms.StatusStrip();
-            this.toolStripStatusLabel2 = new System.Windows.Forms.ToolStripStatusLabel();
-            this.toolStripStatusLabel_currentTime = new System.Windows.Forms.ToolStripStatusLabel();
-            this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
-            this.toolStripStatusLabel_sequenceLength = new System.Windows.Forms.ToolStripStatusLabel();
-            this.toolStripStatusLabel3 = new System.Windows.Forms.ToolStripStatusLabel();
-            this.toolStripStatusLabel_delayPlay = new System.Windows.Forms.ToolStripStatusLabel();
-            this.toolStripStatusLabel4 = new System.Windows.Forms.ToolStripStatusLabel();
-            this.toolStripStatusLabel_RenderingElements = new System.Windows.Forms.ToolStripStatusLabel();
-            this.toolStripProgressBar_RenderingElements = new System.Windows.Forms.ToolStripProgressBar();
-            this.openFileDialog = new System.Windows.Forms.OpenFileDialog();
-            this.toolStripContainer = new System.Windows.Forms.ToolStripContainer();
-            this.dockPanel = new WeifenLuo.WinFormsUI.Docking.DockPanel();
-            this.toolStripExVirtualEffects = new Common.Controls.ToolStripEx();
-            this.toolStripLabelVirtualEffects = new System.Windows.Forms.ToolStripLabel();
-            this.toolStripButtonVirtualEffectsAdd = new System.Windows.Forms.ToolStripButton();
-            this.toolStripButtonVirtualEffectsRemove = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparatorBeginEffects = new System.Windows.Forms.ToolStripSeparator();
-            this.saveFileDialog = new System.Windows.Forms.SaveFileDialog();
-            this.contextMenuStripElementSelection = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.timerPostponePlay = new System.Windows.Forms.Timer(this.components);
-            this.timerDelayCountdown = new System.Windows.Forms.Timer(this.components);
-            this.toolStripOperations.SuspendLayout();
-            this.menuStrip.SuspendLayout();
-            this.statusStrip.SuspendLayout();
-            this.toolStripContainer.ContentPanel.SuspendLayout();
-            this.toolStripContainer.TopToolStripPanel.SuspendLayout();
-            this.toolStripContainer.SuspendLayout();
-            this.toolStripExVirtualEffects.SuspendLayout();
-            this.SuspendLayout();
-            // 
-            // toolStripOperations
-            // 
-            this.toolStripOperations.ClickThrough = true;
-            this.toolStripOperations.Dock = System.Windows.Forms.DockStyle.None;
-            this.toolStripOperations.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.components = new System.ComponentModel.Container();
+			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(TimedSequenceEditorForm));
+			WeifenLuo.WinFormsUI.Docking.DockPanelSkin dockPanelSkin2 = new WeifenLuo.WinFormsUI.Docking.DockPanelSkin();
+			WeifenLuo.WinFormsUI.Docking.AutoHideStripSkin autoHideStripSkin2 = new WeifenLuo.WinFormsUI.Docking.AutoHideStripSkin();
+			WeifenLuo.WinFormsUI.Docking.DockPanelGradient dockPanelGradient4 = new WeifenLuo.WinFormsUI.Docking.DockPanelGradient();
+			WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient8 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
+			WeifenLuo.WinFormsUI.Docking.DockPaneStripSkin dockPaneStripSkin2 = new WeifenLuo.WinFormsUI.Docking.DockPaneStripSkin();
+			WeifenLuo.WinFormsUI.Docking.DockPaneStripGradient dockPaneStripGradient2 = new WeifenLuo.WinFormsUI.Docking.DockPaneStripGradient();
+			WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient9 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
+			WeifenLuo.WinFormsUI.Docking.DockPanelGradient dockPanelGradient5 = new WeifenLuo.WinFormsUI.Docking.DockPanelGradient();
+			WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient10 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
+			WeifenLuo.WinFormsUI.Docking.DockPaneStripToolWindowGradient dockPaneStripToolWindowGradient2 = new WeifenLuo.WinFormsUI.Docking.DockPaneStripToolWindowGradient();
+			WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient11 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
+			WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient12 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
+			WeifenLuo.WinFormsUI.Docking.DockPanelGradient dockPanelGradient6 = new WeifenLuo.WinFormsUI.Docking.DockPanelGradient();
+			WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient13 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
+			WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient14 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
+			this.toolStripOperations = new Common.Controls.ToolStripEx();
+			this.toolStripButton_Start = new System.Windows.Forms.ToolStripButton();
+			this.toolStripButton_Play = new System.Windows.Forms.ToolStripButton();
+			this.toolStripButton_Stop = new System.Windows.Forms.ToolStripButton();
+			this.toolStripButton_Pause = new System.Windows.Forms.ToolStripButton();
+			this.toolStripButton_End = new System.Windows.Forms.ToolStripButton();
+			this.toolStripButton_Loop = new System.Windows.Forms.ToolStripButton();
+			this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
+			this.undoButton = new Common.Controls.UndoButton();
+			this.redoButton = new Common.Controls.UndoButton();
+			this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripButton_Cut = new System.Windows.Forms.ToolStripButton();
+			this.toolStripButton_Copy = new System.Windows.Forms.ToolStripButton();
+			this.toolStripButton_Paste = new System.Windows.Forms.ToolStripButton();
+			this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripButton_AssociateAudio = new System.Windows.Forms.ToolStripButton();
+			this.toolStripButton_MarkManager = new System.Windows.Forms.ToolStripButton();
+			this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripButton_ZoomTimeIn = new System.Windows.Forms.ToolStripButton();
+			this.toolStripButton_ZoomTimeOut = new System.Windows.Forms.ToolStripButton();
+			this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripButton_DrawMode = new System.Windows.Forms.ToolStripButton();
+			this.toolStripButton_SelectionMode = new System.Windows.Forms.ToolStripButton();
+			this.toolStripButton_SnapTo = new System.Windows.Forms.ToolStripButton();
+			this.toolStripDropDownButton_SnapToStrength = new System.Windows.Forms.ToolStripDropDownButton();
+			this.toolStripMenuItem_SnapStrength_1 = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem_SnapStrength_2 = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem_SnapStrength_3 = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem_SnapStrength_4 = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripButton_DragBoxFilter = new System.Windows.Forms.ToolStripButton();
+			this.toolStripDropDownButton_DragBoxFilter = new System.Windows.Forms.ToolStripDropDownButton();
+			this.toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripLabel_TimingSpeedLabel = new System.Windows.Forms.ToolStripLabel();
+			this.toolStripLabel_TimingSpeed = new System.Windows.Forms.ToolStripLabel();
+			this.toolStripButton_IncreaseTimingSpeed = new System.Windows.Forms.ToolStripButton();
+			this.toolStripButton_DecreaseTimingSpeed = new System.Windows.Forms.ToolStripButton();
+			this.toolStripSeparator12 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripLabel3 = new System.Windows.Forms.ToolStripLabel();
+			this.cboAudioDevices = new System.Windows.Forms.ToolStripComboBox();
+			this.menuStrip = new Common.Controls.MenuStripEx();
+			this.sequenceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem_Save = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem_SaveAs = new System.Windows.Forms.ToolStripMenuItem();
+			this.autoSaveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripSeparator15 = new System.Windows.Forms.ToolStripSeparator();
+			this.playbackToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.playToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.pauseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.stopToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem_Loop = new System.Windows.Forms.ToolStripMenuItem();
+			this.playOptionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.delayOffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.delay5SecondsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.delay10SecondsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.delay20SecondsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.delay30SecondsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.delay60SecondsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripSeparator16 = new System.Windows.Forms.ToolStripSeparator();
+			this.exportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripMenuItem_Close = new System.Windows.Forms.ToolStripMenuItem();
+			this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.addEffectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem_EditEffect = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripMenuItem_Cut = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem_Copy = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem_Paste = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+			this.selectAllElementsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem_deleteElements = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripMenuItem_SnapTo = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem_ResizeIndicator = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem_RIColor_Blue = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem_RIColor_Yellow = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem_RIColor_Green = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem_RIColor_White = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem_RIColor_Red = new System.Windows.Forms.ToolStripMenuItem();
+			this.viewToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem_zoomTimeIn = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem_zoomTimeOut = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem_zoomRowsIn = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem_zoomRowsOut = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+			this.effectWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.markWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem_associateAudio = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem_removeAudio = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem_MarkManager = new System.Windows.Forms.ToolStripMenuItem();
+			this.modifySequenceLengthToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.curveEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.colorGradientEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ColorCollectionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.lipSyncMappingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.defaultMapToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.phonemeMappingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.changeMapToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.lyricConverterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.papagayoImportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.bulkEffectMoveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.helpDocumentationToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.timerPlaying = new System.Windows.Forms.Timer(this.components);
+			this.statusStrip = new System.Windows.Forms.StatusStrip();
+			this.toolStripStatusLabel2 = new System.Windows.Forms.ToolStripStatusLabel();
+			this.toolStripStatusLabel_currentTime = new System.Windows.Forms.ToolStripStatusLabel();
+			this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
+			this.toolStripStatusLabel_sequenceLength = new System.Windows.Forms.ToolStripStatusLabel();
+			this.toolStripStatusLabel3 = new System.Windows.Forms.ToolStripStatusLabel();
+			this.toolStripStatusLabel_delayPlay = new System.Windows.Forms.ToolStripStatusLabel();
+			this.toolStripStatusLabel4 = new System.Windows.Forms.ToolStripStatusLabel();
+			this.toolStripStatusLabel_RenderingElements = new System.Windows.Forms.ToolStripStatusLabel();
+			this.toolStripProgressBar_RenderingElements = new System.Windows.Forms.ToolStripProgressBar();
+			this.openFileDialog = new System.Windows.Forms.OpenFileDialog();
+			this.toolStripContainer = new System.Windows.Forms.ToolStripContainer();
+			this.dockPanel = new WeifenLuo.WinFormsUI.Docking.DockPanel();
+			this.toolStripExVirtualEffects = new Common.Controls.ToolStripEx();
+			this.toolStripLabelVirtualEffects = new System.Windows.Forms.ToolStripLabel();
+			this.toolStripButtonVirtualEffectsAdd = new System.Windows.Forms.ToolStripButton();
+			this.toolStripButtonVirtualEffectsRemove = new System.Windows.Forms.ToolStripButton();
+			this.toolStripSeparatorBeginEffects = new System.Windows.Forms.ToolStripSeparator();
+			this.saveFileDialog = new System.Windows.Forms.SaveFileDialog();
+			this.contextMenuStripElementSelection = new System.Windows.Forms.ContextMenuStrip(this.components);
+			this.timerPostponePlay = new System.Windows.Forms.Timer(this.components);
+			this.timerDelayCountdown = new System.Windows.Forms.Timer(this.components);
+			this.cADStyleSelectionBoxToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripOperations.SuspendLayout();
+			this.menuStrip.SuspendLayout();
+			this.statusStrip.SuspendLayout();
+			this.toolStripContainer.ContentPanel.SuspendLayout();
+			this.toolStripContainer.TopToolStripPanel.SuspendLayout();
+			this.toolStripContainer.SuspendLayout();
+			this.toolStripExVirtualEffects.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// toolStripOperations
+			// 
+			this.toolStripOperations.ClickThrough = true;
+			this.toolStripOperations.Dock = System.Windows.Forms.DockStyle.None;
+			this.toolStripOperations.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripButton_Start,
             this.toolStripButton_Play,
             this.toolStripButton_Stop,
@@ -210,364 +211,364 @@ namespace VixenModules.Editor.TimedSequenceEditor
             this.toolStripSeparator12,
             this.toolStripLabel3,
             this.cboAudioDevices});
-            this.toolStripOperations.Location = new System.Drawing.Point(3, 0);
-            this.toolStripOperations.Name = "toolStripOperations";
-            this.toolStripOperations.Size = new System.Drawing.Size(1167, 25);
-            this.toolStripOperations.TabIndex = 1;
-            this.toolStripOperations.Text = "Operations";
-            // 
-            // toolStripButton_Start
-            // 
-            this.toolStripButton_Start.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripButton_Start.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.toolStripButton_Start.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripButton_Start.Name = "toolStripButton_Start";
-            this.toolStripButton_Start.Size = new System.Drawing.Size(35, 22);
-            this.toolStripButton_Start.Text = "Start";
-            this.toolStripButton_Start.Click += new System.EventHandler(this.toolStripButton_Start_Click);
-            // 
-            // toolStripButton_Play
-            // 
-            this.toolStripButton_Play.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripButton_Play.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.toolStripButton_Play.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripButton_Play.Name = "toolStripButton_Play";
-            this.toolStripButton_Play.Size = new System.Drawing.Size(31, 22);
-            this.toolStripButton_Play.Text = "Play";
-            this.toolStripButton_Play.ToolTipText = "Play F5";
-            this.toolStripButton_Play.Click += new System.EventHandler(this.toolStripButton_Play_Click);
-            // 
-            // toolStripButton_Stop
-            // 
-            this.toolStripButton_Stop.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripButton_Stop.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.toolStripButton_Stop.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripButton_Stop.Name = "toolStripButton_Stop";
-            this.toolStripButton_Stop.Size = new System.Drawing.Size(33, 22);
-            this.toolStripButton_Stop.Text = "Stop";
-            this.toolStripButton_Stop.ToolTipText = "Stop F8";
-            this.toolStripButton_Stop.Click += new System.EventHandler(this.toolStripButton_Stop_Click);
-            // 
-            // toolStripButton_Pause
-            // 
-            this.toolStripButton_Pause.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripButton_Pause.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.toolStripButton_Pause.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripButton_Pause.Name = "toolStripButton_Pause";
-            this.toolStripButton_Pause.Size = new System.Drawing.Size(40, 22);
-            this.toolStripButton_Pause.Text = "Pause";
-            this.toolStripButton_Pause.ToolTipText = "Pause F6";
-            this.toolStripButton_Pause.Click += new System.EventHandler(this.toolStripButton_Pause_Click);
-            // 
-            // toolStripButton_End
-            // 
-            this.toolStripButton_End.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripButton_End.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.toolStripButton_End.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripButton_End.Name = "toolStripButton_End";
-            this.toolStripButton_End.Size = new System.Drawing.Size(29, 22);
-            this.toolStripButton_End.Text = "End";
-            this.toolStripButton_End.Click += new System.EventHandler(this.toolStripButton_End_Click);
-            // 
-            // toolStripButton_Loop
-            // 
-            this.toolStripButton_Loop.CheckOnClick = true;
-            this.toolStripButton_Loop.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripButton_Loop.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.toolStripButton_Loop.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripButton_Loop.Name = "toolStripButton_Loop";
-            this.toolStripButton_Loop.Size = new System.Drawing.Size(34, 22);
-            this.toolStripButton_Loop.Text = "Loop";
-            this.toolStripButton_Loop.ToolTipText = "Loop F9";
-            this.toolStripButton_Loop.CheckedChanged += new System.EventHandler(this.toolStripButton_Loop_CheckedChanged);
-            // 
-            // toolStripSeparator4
-            // 
-            this.toolStripSeparator4.Name = "toolStripSeparator4";
-            this.toolStripSeparator4.Size = new System.Drawing.Size(6, 25);
-            // 
-            // undoButton
-            // 
-            this.undoButton.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.undoButton.ButtonType = Common.Controls.UndoButtonType.UndoButton;
-            this.undoButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.undoButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.undoButton.Name = "undoButton";
-            this.undoButton.Size = new System.Drawing.Size(48, 22);
-            this.undoButton.Text = "Undo";
-            this.undoButton.ButtonClick += new System.EventHandler(this.undoButton_ButtonClick);
-            // 
-            // redoButton
-            // 
-            this.redoButton.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.redoButton.ButtonType = Common.Controls.UndoButtonType.UndoButton;
-            this.redoButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.redoButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.redoButton.Name = "redoButton";
-            this.redoButton.Size = new System.Drawing.Size(48, 22);
-            this.redoButton.Text = "Redo";
-            this.redoButton.ButtonClick += new System.EventHandler(this.redoButton_ButtonClick);
-            // 
-            // toolStripSeparator5
-            // 
-            this.toolStripSeparator5.Name = "toolStripSeparator5";
-            this.toolStripSeparator5.Size = new System.Drawing.Size(6, 25);
-            // 
-            // toolStripButton_Cut
-            // 
-            this.toolStripButton_Cut.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripButton_Cut.Enabled = false;
-            this.toolStripButton_Cut.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.toolStripButton_Cut.Name = "toolStripButton_Cut";
-            this.toolStripButton_Cut.Size = new System.Drawing.Size(28, 22);
-            this.toolStripButton_Cut.Text = "Cut";
-            this.toolStripButton_Cut.Click += new System.EventHandler(this.toolStripMenuItem_Cut_Click);
-            // 
-            // toolStripButton_Copy
-            // 
-            this.toolStripButton_Copy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripButton_Copy.Enabled = false;
-            this.toolStripButton_Copy.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.toolStripButton_Copy.Name = "toolStripButton_Copy";
-            this.toolStripButton_Copy.Size = new System.Drawing.Size(36, 22);
-            this.toolStripButton_Copy.Text = "Copy";
-            this.toolStripButton_Copy.Click += new System.EventHandler(this.toolStripMenuItem_Copy_Click);
-            // 
-            // toolStripButton_Paste
-            // 
-            this.toolStripButton_Paste.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripButton_Paste.Enabled = false;
-            this.toolStripButton_Paste.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.toolStripButton_Paste.Name = "toolStripButton_Paste";
-            this.toolStripButton_Paste.Size = new System.Drawing.Size(38, 22);
-            this.toolStripButton_Paste.Text = "Paste";
-            this.toolStripButton_Paste.Click += new System.EventHandler(this.toolStripMenuItem_Paste_Click);
-            // 
-            // toolStripSeparator8
-            // 
-            this.toolStripSeparator8.AutoSize = false;
-            this.toolStripSeparator8.Name = "toolStripSeparator8";
-            this.toolStripSeparator8.Size = new System.Drawing.Size(6, 25);
-            // 
-            // toolStripButton_AssociateAudio
-            // 
-            this.toolStripButton_AssociateAudio.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripButton_AssociateAudio.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.toolStripButton_AssociateAudio.Name = "toolStripButton_AssociateAudio";
-            this.toolStripButton_AssociateAudio.Size = new System.Drawing.Size(87, 22);
-            this.toolStripButton_AssociateAudio.Text = "Associate Audio";
-            this.toolStripButton_AssociateAudio.Click += new System.EventHandler(this.toolStripMenuItem_associateAudio_Click);
-            // 
-            // toolStripButton_MarkManager
-            // 
-            this.toolStripButton_MarkManager.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripButton_MarkManager.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.toolStripButton_MarkManager.Name = "toolStripButton_MarkManager";
-            this.toolStripButton_MarkManager.Size = new System.Drawing.Size(79, 22);
-            this.toolStripButton_MarkManager.Text = "Mark Manager";
-            this.toolStripButton_MarkManager.Click += new System.EventHandler(this.toolStripMenuItem_MarkManager_Click);
-            // 
-            // toolStripSeparator7
-            // 
-            this.toolStripSeparator7.AutoSize = false;
-            this.toolStripSeparator7.Name = "toolStripSeparator7";
-            this.toolStripSeparator7.Size = new System.Drawing.Size(6, 25);
-            // 
-            // toolStripButton_ZoomTimeIn
-            // 
-            this.toolStripButton_ZoomTimeIn.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripButton_ZoomTimeIn.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.toolStripButton_ZoomTimeIn.Name = "toolStripButton_ZoomTimeIn";
-            this.toolStripButton_ZoomTimeIn.Size = new System.Drawing.Size(75, 22);
-            this.toolStripButton_ZoomTimeIn.Text = "Zoom Time In";
-            this.toolStripButton_ZoomTimeIn.Click += new System.EventHandler(this.toolStripMenuItem_zoomTimeIn_Click);
-            // 
-            // toolStripButton_ZoomTimeOut
-            // 
-            this.toolStripButton_ZoomTimeOut.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripButton_ZoomTimeOut.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.toolStripButton_ZoomTimeOut.Name = "toolStripButton_ZoomTimeOut";
-            this.toolStripButton_ZoomTimeOut.Size = new System.Drawing.Size(83, 22);
-            this.toolStripButton_ZoomTimeOut.Text = "Zoom Time Out";
-            this.toolStripButton_ZoomTimeOut.Click += new System.EventHandler(this.toolStripMenuItem_zoomTimeOut_Click);
-            // 
-            // toolStripSeparator9
-            // 
-            this.toolStripSeparator9.Name = "toolStripSeparator9";
-            this.toolStripSeparator9.Size = new System.Drawing.Size(6, 25);
-            // 
-            // toolStripButton_DrawMode
-            // 
-            this.toolStripButton_DrawMode.CheckOnClick = true;
-            this.toolStripButton_DrawMode.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripButton_DrawMode.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.toolStripButton_DrawMode.Name = "toolStripButton_DrawMode";
-            this.toolStripButton_DrawMode.Size = new System.Drawing.Size(65, 22);
-            this.toolStripButton_DrawMode.Text = "Draw Mode";
-            this.toolStripButton_DrawMode.ToolTipText = "Draw Mode";
-            this.toolStripButton_DrawMode.Click += new System.EventHandler(this.toolStripButton_DrawMode_Click);
-            // 
-            // toolStripButton_SelectionMode
-            // 
-            this.toolStripButton_SelectionMode.Checked = true;
-            this.toolStripButton_SelectionMode.CheckOnClick = true;
-            this.toolStripButton_SelectionMode.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.toolStripButton_SelectionMode.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripButton_SelectionMode.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.toolStripButton_SelectionMode.Name = "toolStripButton_SelectionMode";
-            this.toolStripButton_SelectionMode.Size = new System.Drawing.Size(83, 22);
-            this.toolStripButton_SelectionMode.Text = "Selection Mode";
-            this.toolStripButton_SelectionMode.Click += new System.EventHandler(this.toolStripButton_SelectionMode_Click);
-            // 
-            // toolStripButton_SnapTo
-            // 
-            this.toolStripButton_SnapTo.CheckOnClick = true;
-            this.toolStripButton_SnapTo.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripButton_SnapTo.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.toolStripButton_SnapTo.Name = "toolStripButton_SnapTo";
-            this.toolStripButton_SnapTo.Size = new System.Drawing.Size(50, 22);
-            this.toolStripButton_SnapTo.Text = "Snap To";
-            this.toolStripButton_SnapTo.ToolTipText = "Snap To Marks / Elements";
-            this.toolStripButton_SnapTo.CheckedChanged += new System.EventHandler(this.toolStripButton_SnapTo_CheckedChanged);
-            // 
-            // toolStripDropDownButton_SnapToStrength
-            // 
-            this.toolStripDropDownButton_SnapToStrength.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.None;
-            this.toolStripDropDownButton_SnapToStrength.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.toolStripOperations.Location = new System.Drawing.Point(3, 0);
+			this.toolStripOperations.Name = "toolStripOperations";
+			this.toolStripOperations.Size = new System.Drawing.Size(1167, 27);
+			this.toolStripOperations.TabIndex = 1;
+			this.toolStripOperations.Text = "Operations";
+			// 
+			// toolStripButton_Start
+			// 
+			this.toolStripButton_Start.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.toolStripButton_Start.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+			this.toolStripButton_Start.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.toolStripButton_Start.Name = "toolStripButton_Start";
+			this.toolStripButton_Start.Size = new System.Drawing.Size(35, 24);
+			this.toolStripButton_Start.Text = "Start";
+			this.toolStripButton_Start.Click += new System.EventHandler(this.toolStripButton_Start_Click);
+			// 
+			// toolStripButton_Play
+			// 
+			this.toolStripButton_Play.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.toolStripButton_Play.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+			this.toolStripButton_Play.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.toolStripButton_Play.Name = "toolStripButton_Play";
+			this.toolStripButton_Play.Size = new System.Drawing.Size(33, 24);
+			this.toolStripButton_Play.Text = "Play";
+			this.toolStripButton_Play.ToolTipText = "Play F5";
+			this.toolStripButton_Play.Click += new System.EventHandler(this.toolStripButton_Play_Click);
+			// 
+			// toolStripButton_Stop
+			// 
+			this.toolStripButton_Stop.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.toolStripButton_Stop.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+			this.toolStripButton_Stop.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.toolStripButton_Stop.Name = "toolStripButton_Stop";
+			this.toolStripButton_Stop.Size = new System.Drawing.Size(35, 24);
+			this.toolStripButton_Stop.Text = "Stop";
+			this.toolStripButton_Stop.ToolTipText = "Stop F8";
+			this.toolStripButton_Stop.Click += new System.EventHandler(this.toolStripButton_Stop_Click);
+			// 
+			// toolStripButton_Pause
+			// 
+			this.toolStripButton_Pause.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.toolStripButton_Pause.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+			this.toolStripButton_Pause.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.toolStripButton_Pause.Name = "toolStripButton_Pause";
+			this.toolStripButton_Pause.Size = new System.Drawing.Size(42, 24);
+			this.toolStripButton_Pause.Text = "Pause";
+			this.toolStripButton_Pause.ToolTipText = "Pause F6";
+			this.toolStripButton_Pause.Click += new System.EventHandler(this.toolStripButton_Pause_Click);
+			// 
+			// toolStripButton_End
+			// 
+			this.toolStripButton_End.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.toolStripButton_End.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+			this.toolStripButton_End.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.toolStripButton_End.Name = "toolStripButton_End";
+			this.toolStripButton_End.Size = new System.Drawing.Size(31, 24);
+			this.toolStripButton_End.Text = "End";
+			this.toolStripButton_End.Click += new System.EventHandler(this.toolStripButton_End_Click);
+			// 
+			// toolStripButton_Loop
+			// 
+			this.toolStripButton_Loop.CheckOnClick = true;
+			this.toolStripButton_Loop.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.toolStripButton_Loop.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+			this.toolStripButton_Loop.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.toolStripButton_Loop.Name = "toolStripButton_Loop";
+			this.toolStripButton_Loop.Size = new System.Drawing.Size(38, 24);
+			this.toolStripButton_Loop.Text = "Loop";
+			this.toolStripButton_Loop.ToolTipText = "Loop F9";
+			this.toolStripButton_Loop.CheckedChanged += new System.EventHandler(this.toolStripButton_Loop_CheckedChanged);
+			// 
+			// toolStripSeparator4
+			// 
+			this.toolStripSeparator4.Name = "toolStripSeparator4";
+			this.toolStripSeparator4.Size = new System.Drawing.Size(6, 27);
+			// 
+			// undoButton
+			// 
+			this.undoButton.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+			this.undoButton.ButtonType = Common.Controls.UndoButtonType.UndoButton;
+			this.undoButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.undoButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+			this.undoButton.Name = "undoButton";
+			this.undoButton.Size = new System.Drawing.Size(52, 24);
+			this.undoButton.Text = "Undo";
+			this.undoButton.ButtonClick += new System.EventHandler(this.undoButton_ButtonClick);
+			// 
+			// redoButton
+			// 
+			this.redoButton.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+			this.redoButton.ButtonType = Common.Controls.UndoButtonType.UndoButton;
+			this.redoButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.redoButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+			this.redoButton.Name = "redoButton";
+			this.redoButton.Size = new System.Drawing.Size(50, 24);
+			this.redoButton.Text = "Redo";
+			this.redoButton.ButtonClick += new System.EventHandler(this.redoButton_ButtonClick);
+			// 
+			// toolStripSeparator5
+			// 
+			this.toolStripSeparator5.Name = "toolStripSeparator5";
+			this.toolStripSeparator5.Size = new System.Drawing.Size(6, 27);
+			// 
+			// toolStripButton_Cut
+			// 
+			this.toolStripButton_Cut.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.toolStripButton_Cut.Enabled = false;
+			this.toolStripButton_Cut.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+			this.toolStripButton_Cut.Name = "toolStripButton_Cut";
+			this.toolStripButton_Cut.Size = new System.Drawing.Size(30, 24);
+			this.toolStripButton_Cut.Text = "Cut";
+			this.toolStripButton_Cut.Click += new System.EventHandler(this.toolStripMenuItem_Cut_Click);
+			// 
+			// toolStripButton_Copy
+			// 
+			this.toolStripButton_Copy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.toolStripButton_Copy.Enabled = false;
+			this.toolStripButton_Copy.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+			this.toolStripButton_Copy.Name = "toolStripButton_Copy";
+			this.toolStripButton_Copy.Size = new System.Drawing.Size(39, 24);
+			this.toolStripButton_Copy.Text = "Copy";
+			this.toolStripButton_Copy.Click += new System.EventHandler(this.toolStripMenuItem_Copy_Click);
+			// 
+			// toolStripButton_Paste
+			// 
+			this.toolStripButton_Paste.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.toolStripButton_Paste.Enabled = false;
+			this.toolStripButton_Paste.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+			this.toolStripButton_Paste.Name = "toolStripButton_Paste";
+			this.toolStripButton_Paste.Size = new System.Drawing.Size(39, 24);
+			this.toolStripButton_Paste.Text = "Paste";
+			this.toolStripButton_Paste.Click += new System.EventHandler(this.toolStripMenuItem_Paste_Click);
+			// 
+			// toolStripSeparator8
+			// 
+			this.toolStripSeparator8.AutoSize = false;
+			this.toolStripSeparator8.Name = "toolStripSeparator8";
+			this.toolStripSeparator8.Size = new System.Drawing.Size(6, 25);
+			// 
+			// toolStripButton_AssociateAudio
+			// 
+			this.toolStripButton_AssociateAudio.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.toolStripButton_AssociateAudio.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+			this.toolStripButton_AssociateAudio.Name = "toolStripButton_AssociateAudio";
+			this.toolStripButton_AssociateAudio.Size = new System.Drawing.Size(96, 24);
+			this.toolStripButton_AssociateAudio.Text = "Associate Audio";
+			this.toolStripButton_AssociateAudio.Click += new System.EventHandler(this.toolStripMenuItem_associateAudio_Click);
+			// 
+			// toolStripButton_MarkManager
+			// 
+			this.toolStripButton_MarkManager.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.toolStripButton_MarkManager.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+			this.toolStripButton_MarkManager.Name = "toolStripButton_MarkManager";
+			this.toolStripButton_MarkManager.Size = new System.Drawing.Size(88, 24);
+			this.toolStripButton_MarkManager.Text = "Mark Manager";
+			this.toolStripButton_MarkManager.Click += new System.EventHandler(this.toolStripMenuItem_MarkManager_Click);
+			// 
+			// toolStripSeparator7
+			// 
+			this.toolStripSeparator7.AutoSize = false;
+			this.toolStripSeparator7.Name = "toolStripSeparator7";
+			this.toolStripSeparator7.Size = new System.Drawing.Size(6, 25);
+			// 
+			// toolStripButton_ZoomTimeIn
+			// 
+			this.toolStripButton_ZoomTimeIn.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.toolStripButton_ZoomTimeIn.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+			this.toolStripButton_ZoomTimeIn.Name = "toolStripButton_ZoomTimeIn";
+			this.toolStripButton_ZoomTimeIn.Size = new System.Drawing.Size(86, 24);
+			this.toolStripButton_ZoomTimeIn.Text = "Zoom Time In";
+			this.toolStripButton_ZoomTimeIn.Click += new System.EventHandler(this.toolStripMenuItem_zoomTimeIn_Click);
+			// 
+			// toolStripButton_ZoomTimeOut
+			// 
+			this.toolStripButton_ZoomTimeOut.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.toolStripButton_ZoomTimeOut.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+			this.toolStripButton_ZoomTimeOut.Name = "toolStripButton_ZoomTimeOut";
+			this.toolStripButton_ZoomTimeOut.Size = new System.Drawing.Size(96, 24);
+			this.toolStripButton_ZoomTimeOut.Text = "Zoom Time Out";
+			this.toolStripButton_ZoomTimeOut.Click += new System.EventHandler(this.toolStripMenuItem_zoomTimeOut_Click);
+			// 
+			// toolStripSeparator9
+			// 
+			this.toolStripSeparator9.Name = "toolStripSeparator9";
+			this.toolStripSeparator9.Size = new System.Drawing.Size(6, 27);
+			// 
+			// toolStripButton_DrawMode
+			// 
+			this.toolStripButton_DrawMode.CheckOnClick = true;
+			this.toolStripButton_DrawMode.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.toolStripButton_DrawMode.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+			this.toolStripButton_DrawMode.Name = "toolStripButton_DrawMode";
+			this.toolStripButton_DrawMode.Size = new System.Drawing.Size(72, 24);
+			this.toolStripButton_DrawMode.Text = "Draw Mode";
+			this.toolStripButton_DrawMode.ToolTipText = "Draw Mode";
+			this.toolStripButton_DrawMode.Click += new System.EventHandler(this.toolStripButton_DrawMode_Click);
+			// 
+			// toolStripButton_SelectionMode
+			// 
+			this.toolStripButton_SelectionMode.Checked = true;
+			this.toolStripButton_SelectionMode.CheckOnClick = true;
+			this.toolStripButton_SelectionMode.CheckState = System.Windows.Forms.CheckState.Checked;
+			this.toolStripButton_SelectionMode.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.toolStripButton_SelectionMode.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+			this.toolStripButton_SelectionMode.Name = "toolStripButton_SelectionMode";
+			this.toolStripButton_SelectionMode.Size = new System.Drawing.Size(93, 24);
+			this.toolStripButton_SelectionMode.Text = "Selection Mode";
+			this.toolStripButton_SelectionMode.Click += new System.EventHandler(this.toolStripButton_SelectionMode_Click);
+			// 
+			// toolStripButton_SnapTo
+			// 
+			this.toolStripButton_SnapTo.CheckOnClick = true;
+			this.toolStripButton_SnapTo.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.toolStripButton_SnapTo.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+			this.toolStripButton_SnapTo.Name = "toolStripButton_SnapTo";
+			this.toolStripButton_SnapTo.Size = new System.Drawing.Size(54, 24);
+			this.toolStripButton_SnapTo.Text = "Snap To";
+			this.toolStripButton_SnapTo.ToolTipText = "Snap To Marks / Elements";
+			this.toolStripButton_SnapTo.CheckedChanged += new System.EventHandler(this.toolStripButton_SnapTo_CheckedChanged);
+			// 
+			// toolStripDropDownButton_SnapToStrength
+			// 
+			this.toolStripDropDownButton_SnapToStrength.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.None;
+			this.toolStripDropDownButton_SnapToStrength.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItem_SnapStrength_1,
             this.toolStripMenuItem_SnapStrength_2,
             this.toolStripMenuItem_SnapStrength_3,
             this.toolStripMenuItem_SnapStrength_4});
-            this.toolStripDropDownButton_SnapToStrength.Image = ((System.Drawing.Image)(resources.GetObject("toolStripDropDownButton_SnapToStrength.Image")));
-            this.toolStripDropDownButton_SnapToStrength.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripDropDownButton_SnapToStrength.Name = "toolStripDropDownButton_SnapToStrength";
-            this.toolStripDropDownButton_SnapToStrength.Size = new System.Drawing.Size(13, 22);
-            this.toolStripDropDownButton_SnapToStrength.ToolTipText = "Snap Strength";
-            // 
-            // toolStripMenuItem_SnapStrength_1
-            // 
-            this.toolStripMenuItem_SnapStrength_1.Name = "toolStripMenuItem_SnapStrength_1";
-            this.toolStripMenuItem_SnapStrength_1.Size = new System.Drawing.Size(80, 22);
-            this.toolStripMenuItem_SnapStrength_1.Tag = "2";
-            this.toolStripMenuItem_SnapStrength_1.Text = "1";
-            // 
-            // toolStripMenuItem_SnapStrength_2
-            // 
-            this.toolStripMenuItem_SnapStrength_2.Name = "toolStripMenuItem_SnapStrength_2";
-            this.toolStripMenuItem_SnapStrength_2.ShowShortcutKeys = false;
-            this.toolStripMenuItem_SnapStrength_2.Size = new System.Drawing.Size(80, 22);
-            this.toolStripMenuItem_SnapStrength_2.Tag = "4";
-            this.toolStripMenuItem_SnapStrength_2.Text = "2";
-            // 
-            // toolStripMenuItem_SnapStrength_3
-            // 
-            this.toolStripMenuItem_SnapStrength_3.Name = "toolStripMenuItem_SnapStrength_3";
-            this.toolStripMenuItem_SnapStrength_3.ShowShortcutKeys = false;
-            this.toolStripMenuItem_SnapStrength_3.Size = new System.Drawing.Size(80, 22);
-            this.toolStripMenuItem_SnapStrength_3.Tag = "6";
-            this.toolStripMenuItem_SnapStrength_3.Text = "3";
-            // 
-            // toolStripMenuItem_SnapStrength_4
-            // 
-            this.toolStripMenuItem_SnapStrength_4.Name = "toolStripMenuItem_SnapStrength_4";
-            this.toolStripMenuItem_SnapStrength_4.ShowShortcutKeys = false;
-            this.toolStripMenuItem_SnapStrength_4.Size = new System.Drawing.Size(80, 22);
-            this.toolStripMenuItem_SnapStrength_4.Tag = "8";
-            this.toolStripMenuItem_SnapStrength_4.Text = "4";
-            // 
-            // toolStripButton_DragBoxFilter
-            // 
-            this.toolStripButton_DragBoxFilter.CheckOnClick = true;
-            this.toolStripButton_DragBoxFilter.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripButton_DragBoxFilter.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.toolStripButton_DragBoxFilter.Name = "toolStripButton_DragBoxFilter";
-            this.toolStripButton_DragBoxFilter.Size = new System.Drawing.Size(82, 22);
-            this.toolStripButton_DragBoxFilter.Text = "Drag Box Filter";
-            this.toolStripButton_DragBoxFilter.CheckedChanged += new System.EventHandler(this.toolStripButton_DragBoxFilter_CheckedChanged);
-            // 
-            // toolStripDropDownButton_DragBoxFilter
-            // 
-            this.toolStripDropDownButton_DragBoxFilter.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.None;
-            this.toolStripDropDownButton_DragBoxFilter.Image = ((System.Drawing.Image)(resources.GetObject("toolStripDropDownButton_DragBoxFilter.Image")));
-            this.toolStripDropDownButton_DragBoxFilter.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripDropDownButton_DragBoxFilter.Name = "toolStripDropDownButton_DragBoxFilter";
-            this.toolStripDropDownButton_DragBoxFilter.Size = new System.Drawing.Size(13, 22);
-            this.toolStripDropDownButton_DragBoxFilter.ToolTipText = "Drag Box Filter";
-            // 
-            // toolStripSeparator11
-            // 
-            this.toolStripSeparator11.Name = "toolStripSeparator11";
-            this.toolStripSeparator11.Size = new System.Drawing.Size(6, 25);
-            // 
-            // toolStripLabel_TimingSpeedLabel
-            // 
-            this.toolStripLabel_TimingSpeedLabel.Name = "toolStripLabel_TimingSpeedLabel";
-            this.toolStripLabel_TimingSpeedLabel.Size = new System.Drawing.Size(73, 22);
-            this.toolStripLabel_TimingSpeedLabel.Text = "Timing speed:";
-            // 
-            // toolStripLabel_TimingSpeed
-            // 
-            this.toolStripLabel_TimingSpeed.Name = "toolStripLabel_TimingSpeed";
-            this.toolStripLabel_TimingSpeed.Size = new System.Drawing.Size(36, 13);
-            this.toolStripLabel_TimingSpeed.Text = "100%";
-            // 
-            // toolStripButton_IncreaseTimingSpeed
-            // 
-            this.toolStripButton_IncreaseTimingSpeed.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripButton_IncreaseTimingSpeed.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.toolStripButton_IncreaseTimingSpeed.Name = "toolStripButton_IncreaseTimingSpeed";
-            this.toolStripButton_IncreaseTimingSpeed.Size = new System.Drawing.Size(85, 17);
-            this.toolStripButton_IncreaseTimingSpeed.Text = "Increase speed";
-            this.toolStripButton_IncreaseTimingSpeed.Click += new System.EventHandler(this.toolStripButton_IncreaseTimingSpeed_Click);
-            // 
-            // toolStripButton_DecreaseTimingSpeed
-            // 
-            this.toolStripButton_DecreaseTimingSpeed.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripButton_DecreaseTimingSpeed.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.toolStripButton_DecreaseTimingSpeed.Name = "toolStripButton_DecreaseTimingSpeed";
-            this.toolStripButton_DecreaseTimingSpeed.Size = new System.Drawing.Size(88, 17);
-            this.toolStripButton_DecreaseTimingSpeed.Text = "Decrease speed";
-            this.toolStripButton_DecreaseTimingSpeed.Click += new System.EventHandler(this.toolStripButton_DecreaseTimingSpeed_Click);
-            // 
-            // toolStripSeparator12
-            // 
-            this.toolStripSeparator12.Name = "toolStripSeparator12";
-            this.toolStripSeparator12.Size = new System.Drawing.Size(6, 27);
-            // 
-            // toolStripLabel3
-            // 
-            this.toolStripLabel3.Name = "toolStripLabel3";
-            this.toolStripLabel3.Size = new System.Drawing.Size(69, 13);
-            this.toolStripLabel3.Text = "Audio Device";
-            // 
-            // cboAudioDevices
-            // 
-            this.cboAudioDevices.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cboAudioDevices.DropDownWidth = 220;
-            this.cboAudioDevices.Name = "cboAudioDevices";
-            this.cboAudioDevices.Size = new System.Drawing.Size(250, 21);
-            this.cboAudioDevices.SelectedIndexChanged += new System.EventHandler(this.cboAudioDevices_SelectedIndexChanged);
-            this.cboAudioDevices.TextChanged += new System.EventHandler(this.cboAudioDevices_TextChanged);
-            // 
-            // menuStrip
-            // 
-            this.menuStrip.ClickThrough = true;
-            this.menuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.toolStripDropDownButton_SnapToStrength.Image = ((System.Drawing.Image)(resources.GetObject("toolStripDropDownButton_SnapToStrength.Image")));
+			this.toolStripDropDownButton_SnapToStrength.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.toolStripDropDownButton_SnapToStrength.Name = "toolStripDropDownButton_SnapToStrength";
+			this.toolStripDropDownButton_SnapToStrength.Size = new System.Drawing.Size(13, 24);
+			this.toolStripDropDownButton_SnapToStrength.ToolTipText = "Snap Strength";
+			// 
+			// toolStripMenuItem_SnapStrength_1
+			// 
+			this.toolStripMenuItem_SnapStrength_1.Name = "toolStripMenuItem_SnapStrength_1";
+			this.toolStripMenuItem_SnapStrength_1.Size = new System.Drawing.Size(80, 22);
+			this.toolStripMenuItem_SnapStrength_1.Tag = "2";
+			this.toolStripMenuItem_SnapStrength_1.Text = "1";
+			// 
+			// toolStripMenuItem_SnapStrength_2
+			// 
+			this.toolStripMenuItem_SnapStrength_2.Name = "toolStripMenuItem_SnapStrength_2";
+			this.toolStripMenuItem_SnapStrength_2.ShowShortcutKeys = false;
+			this.toolStripMenuItem_SnapStrength_2.Size = new System.Drawing.Size(80, 22);
+			this.toolStripMenuItem_SnapStrength_2.Tag = "4";
+			this.toolStripMenuItem_SnapStrength_2.Text = "2";
+			// 
+			// toolStripMenuItem_SnapStrength_3
+			// 
+			this.toolStripMenuItem_SnapStrength_3.Name = "toolStripMenuItem_SnapStrength_3";
+			this.toolStripMenuItem_SnapStrength_3.ShowShortcutKeys = false;
+			this.toolStripMenuItem_SnapStrength_3.Size = new System.Drawing.Size(80, 22);
+			this.toolStripMenuItem_SnapStrength_3.Tag = "6";
+			this.toolStripMenuItem_SnapStrength_3.Text = "3";
+			// 
+			// toolStripMenuItem_SnapStrength_4
+			// 
+			this.toolStripMenuItem_SnapStrength_4.Name = "toolStripMenuItem_SnapStrength_4";
+			this.toolStripMenuItem_SnapStrength_4.ShowShortcutKeys = false;
+			this.toolStripMenuItem_SnapStrength_4.Size = new System.Drawing.Size(80, 22);
+			this.toolStripMenuItem_SnapStrength_4.Tag = "8";
+			this.toolStripMenuItem_SnapStrength_4.Text = "4";
+			// 
+			// toolStripButton_DragBoxFilter
+			// 
+			this.toolStripButton_DragBoxFilter.CheckOnClick = true;
+			this.toolStripButton_DragBoxFilter.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.toolStripButton_DragBoxFilter.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+			this.toolStripButton_DragBoxFilter.Name = "toolStripButton_DragBoxFilter";
+			this.toolStripButton_DragBoxFilter.Size = new System.Drawing.Size(87, 24);
+			this.toolStripButton_DragBoxFilter.Text = "Drag Box Filter";
+			this.toolStripButton_DragBoxFilter.CheckedChanged += new System.EventHandler(this.toolStripButton_DragBoxFilter_CheckedChanged);
+			// 
+			// toolStripDropDownButton_DragBoxFilter
+			// 
+			this.toolStripDropDownButton_DragBoxFilter.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.None;
+			this.toolStripDropDownButton_DragBoxFilter.Image = ((System.Drawing.Image)(resources.GetObject("toolStripDropDownButton_DragBoxFilter.Image")));
+			this.toolStripDropDownButton_DragBoxFilter.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.toolStripDropDownButton_DragBoxFilter.Name = "toolStripDropDownButton_DragBoxFilter";
+			this.toolStripDropDownButton_DragBoxFilter.Size = new System.Drawing.Size(13, 4);
+			this.toolStripDropDownButton_DragBoxFilter.ToolTipText = "Drag Box Filter";
+			// 
+			// toolStripSeparator11
+			// 
+			this.toolStripSeparator11.Name = "toolStripSeparator11";
+			this.toolStripSeparator11.Size = new System.Drawing.Size(6, 25);
+			// 
+			// toolStripLabel_TimingSpeedLabel
+			// 
+			this.toolStripLabel_TimingSpeedLabel.Name = "toolStripLabel_TimingSpeedLabel";
+			this.toolStripLabel_TimingSpeedLabel.Size = new System.Drawing.Size(82, 15);
+			this.toolStripLabel_TimingSpeedLabel.Text = "Timing speed:";
+			// 
+			// toolStripLabel_TimingSpeed
+			// 
+			this.toolStripLabel_TimingSpeed.Name = "toolStripLabel_TimingSpeed";
+			this.toolStripLabel_TimingSpeed.Size = new System.Drawing.Size(35, 15);
+			this.toolStripLabel_TimingSpeed.Text = "100%";
+			// 
+			// toolStripButton_IncreaseTimingSpeed
+			// 
+			this.toolStripButton_IncreaseTimingSpeed.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.toolStripButton_IncreaseTimingSpeed.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+			this.toolStripButton_IncreaseTimingSpeed.Name = "toolStripButton_IncreaseTimingSpeed";
+			this.toolStripButton_IncreaseTimingSpeed.Size = new System.Drawing.Size(88, 19);
+			this.toolStripButton_IncreaseTimingSpeed.Text = "Increase speed";
+			this.toolStripButton_IncreaseTimingSpeed.Click += new System.EventHandler(this.toolStripButton_IncreaseTimingSpeed_Click);
+			// 
+			// toolStripButton_DecreaseTimingSpeed
+			// 
+			this.toolStripButton_DecreaseTimingSpeed.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.toolStripButton_DecreaseTimingSpeed.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+			this.toolStripButton_DecreaseTimingSpeed.Name = "toolStripButton_DecreaseTimingSpeed";
+			this.toolStripButton_DecreaseTimingSpeed.Size = new System.Drawing.Size(92, 19);
+			this.toolStripButton_DecreaseTimingSpeed.Text = "Decrease speed";
+			this.toolStripButton_DecreaseTimingSpeed.Click += new System.EventHandler(this.toolStripButton_DecreaseTimingSpeed_Click);
+			// 
+			// toolStripSeparator12
+			// 
+			this.toolStripSeparator12.Name = "toolStripSeparator12";
+			this.toolStripSeparator12.Size = new System.Drawing.Size(6, 27);
+			// 
+			// toolStripLabel3
+			// 
+			this.toolStripLabel3.Name = "toolStripLabel3";
+			this.toolStripLabel3.Size = new System.Drawing.Size(77, 15);
+			this.toolStripLabel3.Text = "Audio Device";
+			// 
+			// cboAudioDevices
+			// 
+			this.cboAudioDevices.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.cboAudioDevices.DropDownWidth = 220;
+			this.cboAudioDevices.Name = "cboAudioDevices";
+			this.cboAudioDevices.Size = new System.Drawing.Size(250, 23);
+			this.cboAudioDevices.SelectedIndexChanged += new System.EventHandler(this.cboAudioDevices_SelectedIndexChanged);
+			this.cboAudioDevices.TextChanged += new System.EventHandler(this.cboAudioDevices_TextChanged);
+			// 
+			// menuStrip
+			// 
+			this.menuStrip.ClickThrough = true;
+			this.menuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.sequenceToolStripMenuItem,
             this.editToolStripMenuItem,
             this.viewToolStripMenuItem,
             this.toolsToolStripMenuItem,
             this.helpDocumentationToolStripMenuItem});
-            this.menuStrip.Location = new System.Drawing.Point(0, 0);
-            this.menuStrip.Name = "menuStrip";
-            this.menuStrip.Size = new System.Drawing.Size(1170, 24);
-            this.menuStrip.TabIndex = 2;
-            this.menuStrip.Text = "Menu";
-            this.menuStrip.MenuActivate += new System.EventHandler(this.menuStrip_MenuActivate);
-            // 
-            // sequenceToolStripMenuItem
-            // 
-            this.sequenceToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.menuStrip.Location = new System.Drawing.Point(0, 0);
+			this.menuStrip.Name = "menuStrip";
+			this.menuStrip.Size = new System.Drawing.Size(1170, 24);
+			this.menuStrip.TabIndex = 2;
+			this.menuStrip.Text = "Menu";
+			this.menuStrip.MenuActivate += new System.EventHandler(this.menuStrip_MenuActivate);
+			// 
+			// sequenceToolStripMenuItem
+			// 
+			this.sequenceToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItem_Save,
             this.toolStripMenuItem_SaveAs,
             this.autoSaveToolStripMenuItem,
@@ -577,173 +578,173 @@ namespace VixenModules.Editor.TimedSequenceEditor
             this.exportToolStripMenuItem,
             this.toolStripSeparator1,
             this.toolStripMenuItem_Close});
-            this.sequenceToolStripMenuItem.Name = "sequenceToolStripMenuItem";
-            this.sequenceToolStripMenuItem.Size = new System.Drawing.Size(66, 20);
-            this.sequenceToolStripMenuItem.Text = "Sequence";
-            // 
-            // toolStripMenuItem_Save
-            // 
-            this.toolStripMenuItem_Save.Name = "toolStripMenuItem_Save";
-            this.toolStripMenuItem_Save.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-            this.toolStripMenuItem_Save.Size = new System.Drawing.Size(184, 22);
-            this.toolStripMenuItem_Save.Text = "Save";
-            this.toolStripMenuItem_Save.Click += new System.EventHandler(this.toolStripMenuItem_Save_Click);
-            // 
-            // toolStripMenuItem_SaveAs
-            // 
-            this.toolStripMenuItem_SaveAs.Name = "toolStripMenuItem_SaveAs";
-            this.toolStripMenuItem_SaveAs.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Alt) 
+			this.sequenceToolStripMenuItem.Name = "sequenceToolStripMenuItem";
+			this.sequenceToolStripMenuItem.Size = new System.Drawing.Size(70, 20);
+			this.sequenceToolStripMenuItem.Text = "Sequence";
+			// 
+			// toolStripMenuItem_Save
+			// 
+			this.toolStripMenuItem_Save.Name = "toolStripMenuItem_Save";
+			this.toolStripMenuItem_Save.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
+			this.toolStripMenuItem_Save.Size = new System.Drawing.Size(186, 22);
+			this.toolStripMenuItem_Save.Text = "Save";
+			this.toolStripMenuItem_Save.Click += new System.EventHandler(this.toolStripMenuItem_Save_Click);
+			// 
+			// toolStripMenuItem_SaveAs
+			// 
+			this.toolStripMenuItem_SaveAs.Name = "toolStripMenuItem_SaveAs";
+			this.toolStripMenuItem_SaveAs.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Alt) 
             | System.Windows.Forms.Keys.S)));
-            this.toolStripMenuItem_SaveAs.Size = new System.Drawing.Size(184, 22);
-            this.toolStripMenuItem_SaveAs.Text = "Save As...";
-            this.toolStripMenuItem_SaveAs.Click += new System.EventHandler(this.toolStripMenuItem_SaveAs_Click);
-            // 
-            // autoSaveToolStripMenuItem
-            // 
-            this.autoSaveToolStripMenuItem.Checked = true;
-            this.autoSaveToolStripMenuItem.CheckOnClick = true;
-            this.autoSaveToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.autoSaveToolStripMenuItem.Name = "autoSaveToolStripMenuItem";
-            this.autoSaveToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
-            this.autoSaveToolStripMenuItem.Text = "Auto Save";
-            this.autoSaveToolStripMenuItem.CheckedChanged += new System.EventHandler(this.toolStripMenuItem_AutoSave_Click);
-            // 
-            // toolStripSeparator15
-            // 
-            this.toolStripSeparator15.Name = "toolStripSeparator15";
-            this.toolStripSeparator15.Size = new System.Drawing.Size(181, 6);
-            // 
-            // playbackToolStripMenuItem
-            // 
-            this.playbackToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.toolStripMenuItem_SaveAs.Size = new System.Drawing.Size(186, 22);
+			this.toolStripMenuItem_SaveAs.Text = "Save As...";
+			this.toolStripMenuItem_SaveAs.Click += new System.EventHandler(this.toolStripMenuItem_SaveAs_Click);
+			// 
+			// autoSaveToolStripMenuItem
+			// 
+			this.autoSaveToolStripMenuItem.Checked = true;
+			this.autoSaveToolStripMenuItem.CheckOnClick = true;
+			this.autoSaveToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+			this.autoSaveToolStripMenuItem.Name = "autoSaveToolStripMenuItem";
+			this.autoSaveToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
+			this.autoSaveToolStripMenuItem.Text = "Auto Save";
+			this.autoSaveToolStripMenuItem.CheckedChanged += new System.EventHandler(this.toolStripMenuItem_AutoSave_Click);
+			// 
+			// toolStripSeparator15
+			// 
+			this.toolStripSeparator15.Name = "toolStripSeparator15";
+			this.toolStripSeparator15.Size = new System.Drawing.Size(183, 6);
+			// 
+			// playbackToolStripMenuItem
+			// 
+			this.playbackToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.playToolStripMenuItem,
             this.pauseToolStripMenuItem,
             this.stopToolStripMenuItem,
             this.toolStripMenuItem_Loop,
             this.playOptionsToolStripMenuItem});
-            this.playbackToolStripMenuItem.Name = "playbackToolStripMenuItem";
-            this.playbackToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
-            this.playbackToolStripMenuItem.Text = "Playback";
-            // 
-            // playToolStripMenuItem
-            // 
-            this.playToolStripMenuItem.Name = "playToolStripMenuItem";
-            this.playToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F5;
-            this.playToolStripMenuItem.Size = new System.Drawing.Size(134, 22);
-            this.playToolStripMenuItem.Text = "Play";
-            this.playToolStripMenuItem.Click += new System.EventHandler(this.playToolStripMenuItem_Click);
-            // 
-            // pauseToolStripMenuItem
-            // 
-            this.pauseToolStripMenuItem.Name = "pauseToolStripMenuItem";
-            this.pauseToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F6;
-            this.pauseToolStripMenuItem.Size = new System.Drawing.Size(134, 22);
-            this.pauseToolStripMenuItem.Text = "Pause";
-            this.pauseToolStripMenuItem.Click += new System.EventHandler(this.pauseToolStripMenuItem_Click);
-            // 
-            // stopToolStripMenuItem
-            // 
-            this.stopToolStripMenuItem.Name = "stopToolStripMenuItem";
-            this.stopToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F8;
-            this.stopToolStripMenuItem.Size = new System.Drawing.Size(134, 22);
-            this.stopToolStripMenuItem.Text = "Stop";
-            this.stopToolStripMenuItem.Click += new System.EventHandler(this.stopToolStripMenuItem_Click);
-            // 
-            // toolStripMenuItem_Loop
-            // 
-            this.toolStripMenuItem_Loop.CheckOnClick = true;
-            this.toolStripMenuItem_Loop.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripMenuItem_Loop.Name = "toolStripMenuItem_Loop";
-            this.toolStripMenuItem_Loop.ShortcutKeys = System.Windows.Forms.Keys.F9;
-            this.toolStripMenuItem_Loop.Size = new System.Drawing.Size(134, 22);
-            this.toolStripMenuItem_Loop.Text = "Loop";
-            this.toolStripMenuItem_Loop.CheckedChanged += new System.EventHandler(this.toolStripMenuItem_Loop_CheckedChanged);
-            // 
-            // playOptionsToolStripMenuItem
-            // 
-            this.playOptionsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.playbackToolStripMenuItem.Name = "playbackToolStripMenuItem";
+			this.playbackToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
+			this.playbackToolStripMenuItem.Text = "Playback";
+			// 
+			// playToolStripMenuItem
+			// 
+			this.playToolStripMenuItem.Name = "playToolStripMenuItem";
+			this.playToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F5;
+			this.playToolStripMenuItem.Size = new System.Drawing.Size(141, 22);
+			this.playToolStripMenuItem.Text = "Play";
+			this.playToolStripMenuItem.Click += new System.EventHandler(this.playToolStripMenuItem_Click);
+			// 
+			// pauseToolStripMenuItem
+			// 
+			this.pauseToolStripMenuItem.Name = "pauseToolStripMenuItem";
+			this.pauseToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F6;
+			this.pauseToolStripMenuItem.Size = new System.Drawing.Size(141, 22);
+			this.pauseToolStripMenuItem.Text = "Pause";
+			this.pauseToolStripMenuItem.Click += new System.EventHandler(this.pauseToolStripMenuItem_Click);
+			// 
+			// stopToolStripMenuItem
+			// 
+			this.stopToolStripMenuItem.Name = "stopToolStripMenuItem";
+			this.stopToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F8;
+			this.stopToolStripMenuItem.Size = new System.Drawing.Size(141, 22);
+			this.stopToolStripMenuItem.Text = "Stop";
+			this.stopToolStripMenuItem.Click += new System.EventHandler(this.stopToolStripMenuItem_Click);
+			// 
+			// toolStripMenuItem_Loop
+			// 
+			this.toolStripMenuItem_Loop.CheckOnClick = true;
+			this.toolStripMenuItem_Loop.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.toolStripMenuItem_Loop.Name = "toolStripMenuItem_Loop";
+			this.toolStripMenuItem_Loop.ShortcutKeys = System.Windows.Forms.Keys.F9;
+			this.toolStripMenuItem_Loop.Size = new System.Drawing.Size(141, 22);
+			this.toolStripMenuItem_Loop.Text = "Loop";
+			this.toolStripMenuItem_Loop.CheckedChanged += new System.EventHandler(this.toolStripMenuItem_Loop_CheckedChanged);
+			// 
+			// playOptionsToolStripMenuItem
+			// 
+			this.playOptionsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.delayOffToolStripMenuItem,
             this.delay5SecondsToolStripMenuItem,
             this.delay10SecondsToolStripMenuItem,
             this.delay20SecondsToolStripMenuItem,
             this.delay30SecondsToolStripMenuItem,
             this.delay60SecondsToolStripMenuItem});
-            this.playOptionsToolStripMenuItem.Name = "playOptionsToolStripMenuItem";
-            this.playOptionsToolStripMenuItem.Size = new System.Drawing.Size(134, 22);
-            this.playOptionsToolStripMenuItem.Text = "Play Options";
-            // 
-            // delayOffToolStripMenuItem
-            // 
-            this.delayOffToolStripMenuItem.Checked = true;
-            this.delayOffToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.delayOffToolStripMenuItem.Name = "delayOffToolStripMenuItem";
-            this.delayOffToolStripMenuItem.Size = new System.Drawing.Size(159, 22);
-            this.delayOffToolStripMenuItem.Text = "Delay Off";
-            this.delayOffToolStripMenuItem.Click += new System.EventHandler(this.delayOffToolStripMenuItem_Click);
-            // 
-            // delay5SecondsToolStripMenuItem
-            // 
-            this.delay5SecondsToolStripMenuItem.Name = "delay5SecondsToolStripMenuItem";
-            this.delay5SecondsToolStripMenuItem.Size = new System.Drawing.Size(159, 22);
-            this.delay5SecondsToolStripMenuItem.Text = "Delay 5 Seconds";
-            this.delay5SecondsToolStripMenuItem.Click += new System.EventHandler(this.delay5SecondsToolStripMenuItem_Click);
-            // 
-            // delay10SecondsToolStripMenuItem
-            // 
-            this.delay10SecondsToolStripMenuItem.Name = "delay10SecondsToolStripMenuItem";
-            this.delay10SecondsToolStripMenuItem.Size = new System.Drawing.Size(159, 22);
-            this.delay10SecondsToolStripMenuItem.Text = "Delay 10 Seconds";
-            this.delay10SecondsToolStripMenuItem.Click += new System.EventHandler(this.delay10SecondsToolStripMenuItem_Click);
-            // 
-            // delay20SecondsToolStripMenuItem
-            // 
-            this.delay20SecondsToolStripMenuItem.Name = "delay20SecondsToolStripMenuItem";
-            this.delay20SecondsToolStripMenuItem.Size = new System.Drawing.Size(159, 22);
-            this.delay20SecondsToolStripMenuItem.Text = "Delay 20 Seconds";
-            this.delay20SecondsToolStripMenuItem.Click += new System.EventHandler(this.delay20SecondsToolStripMenuItem_Click);
-            // 
-            // delay30SecondsToolStripMenuItem
-            // 
-            this.delay30SecondsToolStripMenuItem.Name = "delay30SecondsToolStripMenuItem";
-            this.delay30SecondsToolStripMenuItem.Size = new System.Drawing.Size(159, 22);
-            this.delay30SecondsToolStripMenuItem.Text = "Delay 30 Seconds";
-            this.delay30SecondsToolStripMenuItem.Click += new System.EventHandler(this.delay30SecondsToolStripMenuItem_Click);
-            // 
-            // delay60SecondsToolStripMenuItem
-            // 
-            this.delay60SecondsToolStripMenuItem.Name = "delay60SecondsToolStripMenuItem";
-            this.delay60SecondsToolStripMenuItem.Size = new System.Drawing.Size(159, 22);
-            this.delay60SecondsToolStripMenuItem.Text = "Delay 60 Seconds";
-            this.delay60SecondsToolStripMenuItem.Click += new System.EventHandler(this.delay60SecondsToolStripMenuItem_Click);
-            // 
-            // toolStripSeparator16
-            // 
-            this.toolStripSeparator16.Name = "toolStripSeparator16";
-            this.toolStripSeparator16.Size = new System.Drawing.Size(181, 6);
-            // 
-            // exportToolStripMenuItem
-            // 
-            this.exportToolStripMenuItem.Name = "exportToolStripMenuItem";
-            this.exportToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
-            this.exportToolStripMenuItem.Text = "Export";
-            this.exportToolStripMenuItem.Click += new System.EventHandler(this.exportToolStripMenuItem_Click);
-            // 
-            // toolStripSeparator1
-            // 
-            this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(181, 6);
-            // 
-            // toolStripMenuItem_Close
-            // 
-            this.toolStripMenuItem_Close.Name = "toolStripMenuItem_Close";
-            this.toolStripMenuItem_Close.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Q)));
-            this.toolStripMenuItem_Close.Size = new System.Drawing.Size(184, 22);
-            this.toolStripMenuItem_Close.Text = "Close";
-            this.toolStripMenuItem_Close.Click += new System.EventHandler(this.toolStripMenuItem_Close_Click);
-            // 
-            // editToolStripMenuItem
-            // 
-            this.editToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.playOptionsToolStripMenuItem.Name = "playOptionsToolStripMenuItem";
+			this.playOptionsToolStripMenuItem.Size = new System.Drawing.Size(141, 22);
+			this.playOptionsToolStripMenuItem.Text = "Play Options";
+			// 
+			// delayOffToolStripMenuItem
+			// 
+			this.delayOffToolStripMenuItem.Checked = true;
+			this.delayOffToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+			this.delayOffToolStripMenuItem.Name = "delayOffToolStripMenuItem";
+			this.delayOffToolStripMenuItem.Size = new System.Drawing.Size(165, 22);
+			this.delayOffToolStripMenuItem.Text = "Delay Off";
+			this.delayOffToolStripMenuItem.Click += new System.EventHandler(this.delayOffToolStripMenuItem_Click);
+			// 
+			// delay5SecondsToolStripMenuItem
+			// 
+			this.delay5SecondsToolStripMenuItem.Name = "delay5SecondsToolStripMenuItem";
+			this.delay5SecondsToolStripMenuItem.Size = new System.Drawing.Size(165, 22);
+			this.delay5SecondsToolStripMenuItem.Text = "Delay 5 Seconds";
+			this.delay5SecondsToolStripMenuItem.Click += new System.EventHandler(this.delay5SecondsToolStripMenuItem_Click);
+			// 
+			// delay10SecondsToolStripMenuItem
+			// 
+			this.delay10SecondsToolStripMenuItem.Name = "delay10SecondsToolStripMenuItem";
+			this.delay10SecondsToolStripMenuItem.Size = new System.Drawing.Size(165, 22);
+			this.delay10SecondsToolStripMenuItem.Text = "Delay 10 Seconds";
+			this.delay10SecondsToolStripMenuItem.Click += new System.EventHandler(this.delay10SecondsToolStripMenuItem_Click);
+			// 
+			// delay20SecondsToolStripMenuItem
+			// 
+			this.delay20SecondsToolStripMenuItem.Name = "delay20SecondsToolStripMenuItem";
+			this.delay20SecondsToolStripMenuItem.Size = new System.Drawing.Size(165, 22);
+			this.delay20SecondsToolStripMenuItem.Text = "Delay 20 Seconds";
+			this.delay20SecondsToolStripMenuItem.Click += new System.EventHandler(this.delay20SecondsToolStripMenuItem_Click);
+			// 
+			// delay30SecondsToolStripMenuItem
+			// 
+			this.delay30SecondsToolStripMenuItem.Name = "delay30SecondsToolStripMenuItem";
+			this.delay30SecondsToolStripMenuItem.Size = new System.Drawing.Size(165, 22);
+			this.delay30SecondsToolStripMenuItem.Text = "Delay 30 Seconds";
+			this.delay30SecondsToolStripMenuItem.Click += new System.EventHandler(this.delay30SecondsToolStripMenuItem_Click);
+			// 
+			// delay60SecondsToolStripMenuItem
+			// 
+			this.delay60SecondsToolStripMenuItem.Name = "delay60SecondsToolStripMenuItem";
+			this.delay60SecondsToolStripMenuItem.Size = new System.Drawing.Size(165, 22);
+			this.delay60SecondsToolStripMenuItem.Text = "Delay 60 Seconds";
+			this.delay60SecondsToolStripMenuItem.Click += new System.EventHandler(this.delay60SecondsToolStripMenuItem_Click);
+			// 
+			// toolStripSeparator16
+			// 
+			this.toolStripSeparator16.Name = "toolStripSeparator16";
+			this.toolStripSeparator16.Size = new System.Drawing.Size(183, 6);
+			// 
+			// exportToolStripMenuItem
+			// 
+			this.exportToolStripMenuItem.Name = "exportToolStripMenuItem";
+			this.exportToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
+			this.exportToolStripMenuItem.Text = "Export";
+			this.exportToolStripMenuItem.Click += new System.EventHandler(this.exportToolStripMenuItem_Click);
+			// 
+			// toolStripSeparator1
+			// 
+			this.toolStripSeparator1.Name = "toolStripSeparator1";
+			this.toolStripSeparator1.Size = new System.Drawing.Size(183, 6);
+			// 
+			// toolStripMenuItem_Close
+			// 
+			this.toolStripMenuItem_Close.Name = "toolStripMenuItem_Close";
+			this.toolStripMenuItem_Close.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Q)));
+			this.toolStripMenuItem_Close.Size = new System.Drawing.Size(186, 22);
+			this.toolStripMenuItem_Close.Text = "Close";
+			this.toolStripMenuItem_Close.Click += new System.EventHandler(this.toolStripMenuItem_Close_Click);
+			// 
+			// editToolStripMenuItem
+			// 
+			this.editToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.addEffectToolStripMenuItem,
             this.toolStripMenuItem_EditEffect,
             this.toolStripSeparator2,
@@ -755,146 +756,147 @@ namespace VixenModules.Editor.TimedSequenceEditor
             this.toolStripMenuItem_deleteElements,
             this.toolStripSeparator10,
             this.toolStripMenuItem_SnapTo,
-            this.toolStripMenuItem_ResizeIndicator});
-            this.editToolStripMenuItem.Name = "editToolStripMenuItem";
-            this.editToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
-            this.editToolStripMenuItem.Text = "Edit";
-            // 
-            // addEffectToolStripMenuItem
-            // 
-            this.addEffectToolStripMenuItem.Name = "addEffectToolStripMenuItem";
-            this.addEffectToolStripMenuItem.Size = new System.Drawing.Size(202, 22);
-            this.addEffectToolStripMenuItem.Text = "Add Effect";
-            // 
-            // toolStripMenuItem_EditEffect
-            // 
-            this.toolStripMenuItem_EditEffect.Name = "toolStripMenuItem_EditEffect";
-            this.toolStripMenuItem_EditEffect.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.E)));
-            this.toolStripMenuItem_EditEffect.Size = new System.Drawing.Size(202, 22);
-            this.toolStripMenuItem_EditEffect.Text = "Edit Effect(s)...";
-            this.toolStripMenuItem_EditEffect.Click += new System.EventHandler(this.toolStripMenuItem_EditEffect_Click);
-            // 
-            // toolStripSeparator2
-            // 
-            this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(199, 6);
-            // 
-            // toolStripMenuItem_Cut
-            // 
-            this.toolStripMenuItem_Cut.Enabled = false;
-            this.toolStripMenuItem_Cut.Name = "toolStripMenuItem_Cut";
-            this.toolStripMenuItem_Cut.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X)));
-            this.toolStripMenuItem_Cut.Size = new System.Drawing.Size(202, 22);
-            this.toolStripMenuItem_Cut.Text = "Cut";
-            this.toolStripMenuItem_Cut.Click += new System.EventHandler(this.toolStripMenuItem_Cut_Click);
-            // 
-            // toolStripMenuItem_Copy
-            // 
-            this.toolStripMenuItem_Copy.Enabled = false;
-            this.toolStripMenuItem_Copy.Name = "toolStripMenuItem_Copy";
-            this.toolStripMenuItem_Copy.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-            this.toolStripMenuItem_Copy.Size = new System.Drawing.Size(202, 22);
-            this.toolStripMenuItem_Copy.Text = "Copy";
-            this.toolStripMenuItem_Copy.Click += new System.EventHandler(this.toolStripMenuItem_Copy_Click);
-            // 
-            // toolStripMenuItem_Paste
-            // 
-            this.toolStripMenuItem_Paste.Enabled = false;
-            this.toolStripMenuItem_Paste.Name = "toolStripMenuItem_Paste";
-            this.toolStripMenuItem_Paste.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
-            this.toolStripMenuItem_Paste.Size = new System.Drawing.Size(202, 22);
-            this.toolStripMenuItem_Paste.Text = "Paste";
-            this.toolStripMenuItem_Paste.Click += new System.EventHandler(this.toolStripMenuItem_Paste_Click);
-            // 
-            // toolStripSeparator3
-            // 
-            this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(199, 6);
-            // 
-            // selectAllElementsToolStripMenuItem
-            // 
-            this.selectAllElementsToolStripMenuItem.Name = "selectAllElementsToolStripMenuItem";
-            this.selectAllElementsToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.A)));
-            this.selectAllElementsToolStripMenuItem.Size = new System.Drawing.Size(202, 22);
-            this.selectAllElementsToolStripMenuItem.Text = "Select All Elements";
-            this.selectAllElementsToolStripMenuItem.Click += new System.EventHandler(this.selectAllElementsToolStripMenuItem_Click);
-            // 
-            // toolStripMenuItem_deleteElements
-            // 
-            this.toolStripMenuItem_deleteElements.Name = "toolStripMenuItem_deleteElements";
-            this.toolStripMenuItem_deleteElements.ShortcutKeys = System.Windows.Forms.Keys.Delete;
-            this.toolStripMenuItem_deleteElements.Size = new System.Drawing.Size(202, 22);
-            this.toolStripMenuItem_deleteElements.Text = "Delete Effect(s)";
-            this.toolStripMenuItem_deleteElements.Click += new System.EventHandler(this.toolStripMenuItem_deleteElements_Click);
-            // 
-            // toolStripSeparator10
-            // 
-            this.toolStripSeparator10.Name = "toolStripSeparator10";
-            this.toolStripSeparator10.Size = new System.Drawing.Size(199, 6);
-            // 
-            // toolStripMenuItem_SnapTo
-            // 
-            this.toolStripMenuItem_SnapTo.Checked = true;
-            this.toolStripMenuItem_SnapTo.CheckOnClick = true;
-            this.toolStripMenuItem_SnapTo.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.toolStripMenuItem_SnapTo.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripMenuItem_SnapTo.Name = "toolStripMenuItem_SnapTo";
-            this.toolStripMenuItem_SnapTo.Size = new System.Drawing.Size(202, 22);
-            this.toolStripMenuItem_SnapTo.Text = "Snap To Marks / Elements";
-            this.toolStripMenuItem_SnapTo.CheckedChanged += new System.EventHandler(this.toolStripMenuItem_SnapTo_CheckedChanged);
-            // 
-            // toolStripMenuItem_ResizeIndicator
-            // 
-            this.toolStripMenuItem_ResizeIndicator.CheckOnClick = true;
-            this.toolStripMenuItem_ResizeIndicator.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItem_ResizeIndicator,
+            this.cADStyleSelectionBoxToolStripMenuItem});
+			this.editToolStripMenuItem.Name = "editToolStripMenuItem";
+			this.editToolStripMenuItem.Size = new System.Drawing.Size(39, 20);
+			this.editToolStripMenuItem.Text = "Edit";
+			// 
+			// addEffectToolStripMenuItem
+			// 
+			this.addEffectToolStripMenuItem.Name = "addEffectToolStripMenuItem";
+			this.addEffectToolStripMenuItem.Size = new System.Drawing.Size(215, 22);
+			this.addEffectToolStripMenuItem.Text = "Add Effect";
+			// 
+			// toolStripMenuItem_EditEffect
+			// 
+			this.toolStripMenuItem_EditEffect.Name = "toolStripMenuItem_EditEffect";
+			this.toolStripMenuItem_EditEffect.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.E)));
+			this.toolStripMenuItem_EditEffect.Size = new System.Drawing.Size(215, 22);
+			this.toolStripMenuItem_EditEffect.Text = "Edit Effect(s)...";
+			this.toolStripMenuItem_EditEffect.Click += new System.EventHandler(this.toolStripMenuItem_EditEffect_Click);
+			// 
+			// toolStripSeparator2
+			// 
+			this.toolStripSeparator2.Name = "toolStripSeparator2";
+			this.toolStripSeparator2.Size = new System.Drawing.Size(212, 6);
+			// 
+			// toolStripMenuItem_Cut
+			// 
+			this.toolStripMenuItem_Cut.Enabled = false;
+			this.toolStripMenuItem_Cut.Name = "toolStripMenuItem_Cut";
+			this.toolStripMenuItem_Cut.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X)));
+			this.toolStripMenuItem_Cut.Size = new System.Drawing.Size(215, 22);
+			this.toolStripMenuItem_Cut.Text = "Cut";
+			this.toolStripMenuItem_Cut.Click += new System.EventHandler(this.toolStripMenuItem_Cut_Click);
+			// 
+			// toolStripMenuItem_Copy
+			// 
+			this.toolStripMenuItem_Copy.Enabled = false;
+			this.toolStripMenuItem_Copy.Name = "toolStripMenuItem_Copy";
+			this.toolStripMenuItem_Copy.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
+			this.toolStripMenuItem_Copy.Size = new System.Drawing.Size(215, 22);
+			this.toolStripMenuItem_Copy.Text = "Copy";
+			this.toolStripMenuItem_Copy.Click += new System.EventHandler(this.toolStripMenuItem_Copy_Click);
+			// 
+			// toolStripMenuItem_Paste
+			// 
+			this.toolStripMenuItem_Paste.Enabled = false;
+			this.toolStripMenuItem_Paste.Name = "toolStripMenuItem_Paste";
+			this.toolStripMenuItem_Paste.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
+			this.toolStripMenuItem_Paste.Size = new System.Drawing.Size(215, 22);
+			this.toolStripMenuItem_Paste.Text = "Paste";
+			this.toolStripMenuItem_Paste.Click += new System.EventHandler(this.toolStripMenuItem_Paste_Click);
+			// 
+			// toolStripSeparator3
+			// 
+			this.toolStripSeparator3.Name = "toolStripSeparator3";
+			this.toolStripSeparator3.Size = new System.Drawing.Size(212, 6);
+			// 
+			// selectAllElementsToolStripMenuItem
+			// 
+			this.selectAllElementsToolStripMenuItem.Name = "selectAllElementsToolStripMenuItem";
+			this.selectAllElementsToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.A)));
+			this.selectAllElementsToolStripMenuItem.Size = new System.Drawing.Size(215, 22);
+			this.selectAllElementsToolStripMenuItem.Text = "Select All Elements";
+			this.selectAllElementsToolStripMenuItem.Click += new System.EventHandler(this.selectAllElementsToolStripMenuItem_Click);
+			// 
+			// toolStripMenuItem_deleteElements
+			// 
+			this.toolStripMenuItem_deleteElements.Name = "toolStripMenuItem_deleteElements";
+			this.toolStripMenuItem_deleteElements.ShortcutKeys = System.Windows.Forms.Keys.Delete;
+			this.toolStripMenuItem_deleteElements.Size = new System.Drawing.Size(215, 22);
+			this.toolStripMenuItem_deleteElements.Text = "Delete Effect(s)";
+			this.toolStripMenuItem_deleteElements.Click += new System.EventHandler(this.toolStripMenuItem_deleteElements_Click);
+			// 
+			// toolStripSeparator10
+			// 
+			this.toolStripSeparator10.Name = "toolStripSeparator10";
+			this.toolStripSeparator10.Size = new System.Drawing.Size(212, 6);
+			// 
+			// toolStripMenuItem_SnapTo
+			// 
+			this.toolStripMenuItem_SnapTo.Checked = true;
+			this.toolStripMenuItem_SnapTo.CheckOnClick = true;
+			this.toolStripMenuItem_SnapTo.CheckState = System.Windows.Forms.CheckState.Checked;
+			this.toolStripMenuItem_SnapTo.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.toolStripMenuItem_SnapTo.Name = "toolStripMenuItem_SnapTo";
+			this.toolStripMenuItem_SnapTo.Size = new System.Drawing.Size(215, 22);
+			this.toolStripMenuItem_SnapTo.Text = "Snap To Marks / Elements";
+			this.toolStripMenuItem_SnapTo.CheckedChanged += new System.EventHandler(this.toolStripMenuItem_SnapTo_CheckedChanged);
+			// 
+			// toolStripMenuItem_ResizeIndicator
+			// 
+			this.toolStripMenuItem_ResizeIndicator.CheckOnClick = true;
+			this.toolStripMenuItem_ResizeIndicator.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItem_RIColor_Blue,
             this.toolStripMenuItem_RIColor_Yellow,
             this.toolStripMenuItem_RIColor_Green,
             this.toolStripMenuItem_RIColor_White,
             this.toolStripMenuItem_RIColor_Red});
-            this.toolStripMenuItem_ResizeIndicator.Name = "toolStripMenuItem_ResizeIndicator";
-            this.toolStripMenuItem_ResizeIndicator.Size = new System.Drawing.Size(202, 22);
-            this.toolStripMenuItem_ResizeIndicator.Text = "Resize / Draw Indicator";
-            this.toolStripMenuItem_ResizeIndicator.CheckStateChanged += new System.EventHandler(this.toolStripMenuItem_ResizeIndicator_CheckStateChanged);
-            // 
-            // toolStripMenuItem_RIColor_Blue
-            // 
-            this.toolStripMenuItem_RIColor_Blue.Name = "toolStripMenuItem_RIColor_Blue";
-            this.toolStripMenuItem_RIColor_Blue.Size = new System.Drawing.Size(104, 22);
-            this.toolStripMenuItem_RIColor_Blue.Text = "Blue";
-            this.toolStripMenuItem_RIColor_Blue.Click += new System.EventHandler(this.toolStripMenuItem_RIColor_Blue_Click);
-            // 
-            // toolStripMenuItem_RIColor_Yellow
-            // 
-            this.toolStripMenuItem_RIColor_Yellow.Name = "toolStripMenuItem_RIColor_Yellow";
-            this.toolStripMenuItem_RIColor_Yellow.Size = new System.Drawing.Size(104, 22);
-            this.toolStripMenuItem_RIColor_Yellow.Text = "Yellow";
-            this.toolStripMenuItem_RIColor_Yellow.Click += new System.EventHandler(this.toolStripMenuItem_RIColor_Yellow_Click);
-            // 
-            // toolStripMenuItem_RIColor_Green
-            // 
-            this.toolStripMenuItem_RIColor_Green.Name = "toolStripMenuItem_RIColor_Green";
-            this.toolStripMenuItem_RIColor_Green.Size = new System.Drawing.Size(104, 22);
-            this.toolStripMenuItem_RIColor_Green.Text = "Green";
-            this.toolStripMenuItem_RIColor_Green.Click += new System.EventHandler(this.toolStripMenuItem_RIColor_Green_Click);
-            // 
-            // toolStripMenuItem_RIColor_White
-            // 
-            this.toolStripMenuItem_RIColor_White.Name = "toolStripMenuItem_RIColor_White";
-            this.toolStripMenuItem_RIColor_White.Size = new System.Drawing.Size(104, 22);
-            this.toolStripMenuItem_RIColor_White.Text = "White";
-            this.toolStripMenuItem_RIColor_White.Click += new System.EventHandler(this.toolStripMenuItem_RIColor_White_Click);
-            // 
-            // toolStripMenuItem_RIColor_Red
-            // 
-            this.toolStripMenuItem_RIColor_Red.Name = "toolStripMenuItem_RIColor_Red";
-            this.toolStripMenuItem_RIColor_Red.Size = new System.Drawing.Size(104, 22);
-            this.toolStripMenuItem_RIColor_Red.Text = "Red";
-            this.toolStripMenuItem_RIColor_Red.Click += new System.EventHandler(this.toolStripMenuItem_RIColor_Red_Click);
-            // 
-            // viewToolStripMenuItem
-            // 
-            this.viewToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.toolStripMenuItem_ResizeIndicator.Name = "toolStripMenuItem_ResizeIndicator";
+			this.toolStripMenuItem_ResizeIndicator.Size = new System.Drawing.Size(215, 22);
+			this.toolStripMenuItem_ResizeIndicator.Text = "Resize / Draw Indicator";
+			this.toolStripMenuItem_ResizeIndicator.CheckStateChanged += new System.EventHandler(this.toolStripMenuItem_ResizeIndicator_CheckStateChanged);
+			// 
+			// toolStripMenuItem_RIColor_Blue
+			// 
+			this.toolStripMenuItem_RIColor_Blue.Name = "toolStripMenuItem_RIColor_Blue";
+			this.toolStripMenuItem_RIColor_Blue.Size = new System.Drawing.Size(109, 22);
+			this.toolStripMenuItem_RIColor_Blue.Text = "Blue";
+			this.toolStripMenuItem_RIColor_Blue.Click += new System.EventHandler(this.toolStripMenuItem_RIColor_Blue_Click);
+			// 
+			// toolStripMenuItem_RIColor_Yellow
+			// 
+			this.toolStripMenuItem_RIColor_Yellow.Name = "toolStripMenuItem_RIColor_Yellow";
+			this.toolStripMenuItem_RIColor_Yellow.Size = new System.Drawing.Size(109, 22);
+			this.toolStripMenuItem_RIColor_Yellow.Text = "Yellow";
+			this.toolStripMenuItem_RIColor_Yellow.Click += new System.EventHandler(this.toolStripMenuItem_RIColor_Yellow_Click);
+			// 
+			// toolStripMenuItem_RIColor_Green
+			// 
+			this.toolStripMenuItem_RIColor_Green.Name = "toolStripMenuItem_RIColor_Green";
+			this.toolStripMenuItem_RIColor_Green.Size = new System.Drawing.Size(109, 22);
+			this.toolStripMenuItem_RIColor_Green.Text = "Green";
+			this.toolStripMenuItem_RIColor_Green.Click += new System.EventHandler(this.toolStripMenuItem_RIColor_Green_Click);
+			// 
+			// toolStripMenuItem_RIColor_White
+			// 
+			this.toolStripMenuItem_RIColor_White.Name = "toolStripMenuItem_RIColor_White";
+			this.toolStripMenuItem_RIColor_White.Size = new System.Drawing.Size(109, 22);
+			this.toolStripMenuItem_RIColor_White.Text = "White";
+			this.toolStripMenuItem_RIColor_White.Click += new System.EventHandler(this.toolStripMenuItem_RIColor_White_Click);
+			// 
+			// toolStripMenuItem_RIColor_Red
+			// 
+			this.toolStripMenuItem_RIColor_Red.Name = "toolStripMenuItem_RIColor_Red";
+			this.toolStripMenuItem_RIColor_Red.Size = new System.Drawing.Size(109, 22);
+			this.toolStripMenuItem_RIColor_Red.Text = "Red";
+			this.toolStripMenuItem_RIColor_Red.Click += new System.EventHandler(this.toolStripMenuItem_RIColor_Red_Click);
+			// 
+			// viewToolStripMenuItem
+			// 
+			this.viewToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItem_zoomTimeIn,
             this.toolStripMenuItem_zoomTimeOut,
             this.toolStripMenuItem_zoomRowsIn,
@@ -903,77 +905,77 @@ namespace VixenModules.Editor.TimedSequenceEditor
             this.effectWindowToolStripMenuItem,
             this.markWindowToolStripMenuItem,
             this.toolWindowToolStripMenuItem});
-            this.viewToolStripMenuItem.Name = "viewToolStripMenuItem";
-            this.viewToolStripMenuItem.Size = new System.Drawing.Size(41, 20);
-            this.viewToolStripMenuItem.Text = "View";
-            // 
-            // toolStripMenuItem_zoomTimeIn
-            // 
-            this.toolStripMenuItem_zoomTimeIn.Name = "toolStripMenuItem_zoomTimeIn";
-            this.toolStripMenuItem_zoomTimeIn.ShortcutKeyDisplayString = "Ctrl+ +";
-            this.toolStripMenuItem_zoomTimeIn.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Add)));
-            this.toolStripMenuItem_zoomTimeIn.Size = new System.Drawing.Size(219, 22);
-            this.toolStripMenuItem_zoomTimeIn.Text = "Zoom Time In";
-            this.toolStripMenuItem_zoomTimeIn.Click += new System.EventHandler(this.toolStripMenuItem_zoomTimeIn_Click);
-            // 
-            // toolStripMenuItem_zoomTimeOut
-            // 
-            this.toolStripMenuItem_zoomTimeOut.Name = "toolStripMenuItem_zoomTimeOut";
-            this.toolStripMenuItem_zoomTimeOut.ShortcutKeyDisplayString = "Ctrl+ -";
-            this.toolStripMenuItem_zoomTimeOut.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Subtract)));
-            this.toolStripMenuItem_zoomTimeOut.Size = new System.Drawing.Size(219, 22);
-            this.toolStripMenuItem_zoomTimeOut.Text = "Zoom Time Out";
-            this.toolStripMenuItem_zoomTimeOut.Click += new System.EventHandler(this.toolStripMenuItem_zoomTimeOut_Click);
-            // 
-            // toolStripMenuItem_zoomRowsIn
-            // 
-            this.toolStripMenuItem_zoomRowsIn.Name = "toolStripMenuItem_zoomRowsIn";
-            this.toolStripMenuItem_zoomRowsIn.ShortcutKeyDisplayString = "Ctrl+Shift+ +";
-            this.toolStripMenuItem_zoomRowsIn.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+			this.viewToolStripMenuItem.Name = "viewToolStripMenuItem";
+			this.viewToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
+			this.viewToolStripMenuItem.Text = "View";
+			// 
+			// toolStripMenuItem_zoomTimeIn
+			// 
+			this.toolStripMenuItem_zoomTimeIn.Name = "toolStripMenuItem_zoomTimeIn";
+			this.toolStripMenuItem_zoomTimeIn.ShortcutKeyDisplayString = "Ctrl+ +";
+			this.toolStripMenuItem_zoomTimeIn.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Add)));
+			this.toolStripMenuItem_zoomTimeIn.Size = new System.Drawing.Size(234, 22);
+			this.toolStripMenuItem_zoomTimeIn.Text = "Zoom Time In";
+			this.toolStripMenuItem_zoomTimeIn.Click += new System.EventHandler(this.toolStripMenuItem_zoomTimeIn_Click);
+			// 
+			// toolStripMenuItem_zoomTimeOut
+			// 
+			this.toolStripMenuItem_zoomTimeOut.Name = "toolStripMenuItem_zoomTimeOut";
+			this.toolStripMenuItem_zoomTimeOut.ShortcutKeyDisplayString = "Ctrl+ -";
+			this.toolStripMenuItem_zoomTimeOut.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Subtract)));
+			this.toolStripMenuItem_zoomTimeOut.Size = new System.Drawing.Size(234, 22);
+			this.toolStripMenuItem_zoomTimeOut.Text = "Zoom Time Out";
+			this.toolStripMenuItem_zoomTimeOut.Click += new System.EventHandler(this.toolStripMenuItem_zoomTimeOut_Click);
+			// 
+			// toolStripMenuItem_zoomRowsIn
+			// 
+			this.toolStripMenuItem_zoomRowsIn.Name = "toolStripMenuItem_zoomRowsIn";
+			this.toolStripMenuItem_zoomRowsIn.ShortcutKeyDisplayString = "Ctrl+Shift+ +";
+			this.toolStripMenuItem_zoomRowsIn.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.Add)));
-            this.toolStripMenuItem_zoomRowsIn.Size = new System.Drawing.Size(219, 22);
-            this.toolStripMenuItem_zoomRowsIn.Text = "Zoom Rows In";
-            this.toolStripMenuItem_zoomRowsIn.Click += new System.EventHandler(this.toolStripMenuItem_zoomRowsIn_Click);
-            // 
-            // toolStripMenuItem_zoomRowsOut
-            // 
-            this.toolStripMenuItem_zoomRowsOut.Name = "toolStripMenuItem_zoomRowsOut";
-            this.toolStripMenuItem_zoomRowsOut.ShortcutKeyDisplayString = "Ctrl+Shift+ -";
-            this.toolStripMenuItem_zoomRowsOut.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+			this.toolStripMenuItem_zoomRowsIn.Size = new System.Drawing.Size(234, 22);
+			this.toolStripMenuItem_zoomRowsIn.Text = "Zoom Rows In";
+			this.toolStripMenuItem_zoomRowsIn.Click += new System.EventHandler(this.toolStripMenuItem_zoomRowsIn_Click);
+			// 
+			// toolStripMenuItem_zoomRowsOut
+			// 
+			this.toolStripMenuItem_zoomRowsOut.Name = "toolStripMenuItem_zoomRowsOut";
+			this.toolStripMenuItem_zoomRowsOut.ShortcutKeyDisplayString = "Ctrl+Shift+ -";
+			this.toolStripMenuItem_zoomRowsOut.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.Subtract)));
-            this.toolStripMenuItem_zoomRowsOut.Size = new System.Drawing.Size(219, 22);
-            this.toolStripMenuItem_zoomRowsOut.Text = "Zoom Rows Out";
-            this.toolStripMenuItem_zoomRowsOut.Click += new System.EventHandler(this.toolStripMenuItem_zoomRowsOut_Click);
-            // 
-            // toolStripMenuItem1
-            // 
-            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(216, 6);
-            // 
-            // effectWindowToolStripMenuItem
-            // 
-            this.effectWindowToolStripMenuItem.Name = "effectWindowToolStripMenuItem";
-            this.effectWindowToolStripMenuItem.Size = new System.Drawing.Size(219, 22);
-            this.effectWindowToolStripMenuItem.Text = "Effect Window";
-            this.effectWindowToolStripMenuItem.Click += new System.EventHandler(this.effectWindowToolStripMenuItem_Click);
-            // 
-            // markWindowToolStripMenuItem
-            // 
-            this.markWindowToolStripMenuItem.Name = "markWindowToolStripMenuItem";
-            this.markWindowToolStripMenuItem.Size = new System.Drawing.Size(219, 22);
-            this.markWindowToolStripMenuItem.Text = "Mark Window";
-            this.markWindowToolStripMenuItem.Click += new System.EventHandler(this.markWindowToolStripMenuItem_Click);
-            // 
-            // toolWindowToolStripMenuItem
-            // 
-            this.toolWindowToolStripMenuItem.Name = "toolWindowToolStripMenuItem";
-            this.toolWindowToolStripMenuItem.Size = new System.Drawing.Size(219, 22);
-            this.toolWindowToolStripMenuItem.Text = "Preset Window";
-            this.toolWindowToolStripMenuItem.Click += new System.EventHandler(this.toolWindowToolStripMenuItem_Click);
-            // 
-            // toolsToolStripMenuItem
-            // 
-            this.toolsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.toolStripMenuItem_zoomRowsOut.Size = new System.Drawing.Size(234, 22);
+			this.toolStripMenuItem_zoomRowsOut.Text = "Zoom Rows Out";
+			this.toolStripMenuItem_zoomRowsOut.Click += new System.EventHandler(this.toolStripMenuItem_zoomRowsOut_Click);
+			// 
+			// toolStripMenuItem1
+			// 
+			this.toolStripMenuItem1.Name = "toolStripMenuItem1";
+			this.toolStripMenuItem1.Size = new System.Drawing.Size(231, 6);
+			// 
+			// effectWindowToolStripMenuItem
+			// 
+			this.effectWindowToolStripMenuItem.Name = "effectWindowToolStripMenuItem";
+			this.effectWindowToolStripMenuItem.Size = new System.Drawing.Size(234, 22);
+			this.effectWindowToolStripMenuItem.Text = "Effect Window";
+			this.effectWindowToolStripMenuItem.Click += new System.EventHandler(this.effectWindowToolStripMenuItem_Click);
+			// 
+			// markWindowToolStripMenuItem
+			// 
+			this.markWindowToolStripMenuItem.Name = "markWindowToolStripMenuItem";
+			this.markWindowToolStripMenuItem.Size = new System.Drawing.Size(234, 22);
+			this.markWindowToolStripMenuItem.Text = "Mark Window";
+			this.markWindowToolStripMenuItem.Click += new System.EventHandler(this.markWindowToolStripMenuItem_Click);
+			// 
+			// toolWindowToolStripMenuItem
+			// 
+			this.toolWindowToolStripMenuItem.Name = "toolWindowToolStripMenuItem";
+			this.toolWindowToolStripMenuItem.Size = new System.Drawing.Size(234, 22);
+			this.toolWindowToolStripMenuItem.Text = "Preset Window";
+			this.toolWindowToolStripMenuItem.Click += new System.EventHandler(this.toolWindowToolStripMenuItem_Click);
+			// 
+			// toolsToolStripMenuItem
+			// 
+			this.toolsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItem_associateAudio,
             this.toolStripMenuItem_removeAudio,
             this.toolStripMenuItem_MarkManager,
@@ -983,130 +985,130 @@ namespace VixenModules.Editor.TimedSequenceEditor
             this.ColorCollectionsToolStripMenuItem,
             this.lipSyncMappingsToolStripMenuItem,
             this.bulkEffectMoveToolStripMenuItem});
-            this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
-            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
-            this.toolsToolStripMenuItem.Text = "Tools";
-            // 
-            // toolStripMenuItem_associateAudio
-            // 
-            this.toolStripMenuItem_associateAudio.Name = "toolStripMenuItem_associateAudio";
-            this.toolStripMenuItem_associateAudio.Size = new System.Drawing.Size(179, 22);
-            this.toolStripMenuItem_associateAudio.Text = "Associate Audio...";
-            this.toolStripMenuItem_associateAudio.Click += new System.EventHandler(this.toolStripMenuItem_associateAudio_Click);
-            // 
-            // toolStripMenuItem_removeAudio
-            // 
-            this.toolStripMenuItem_removeAudio.Enabled = false;
-            this.toolStripMenuItem_removeAudio.Name = "toolStripMenuItem_removeAudio";
-            this.toolStripMenuItem_removeAudio.Size = new System.Drawing.Size(179, 22);
-            this.toolStripMenuItem_removeAudio.Text = "Remove Audio";
-            this.toolStripMenuItem_removeAudio.Click += new System.EventHandler(this.toolStripMenuItem_removeAudio_Click);
-            // 
-            // toolStripMenuItem_MarkManager
-            // 
-            this.toolStripMenuItem_MarkManager.Name = "toolStripMenuItem_MarkManager";
-            this.toolStripMenuItem_MarkManager.Size = new System.Drawing.Size(179, 22);
-            this.toolStripMenuItem_MarkManager.Text = "Mark Manager...";
-            this.toolStripMenuItem_MarkManager.Click += new System.EventHandler(this.toolStripMenuItem_MarkManager_Click);
-            // 
-            // modifySequenceLengthToolStripMenuItem
-            // 
-            this.modifySequenceLengthToolStripMenuItem.Name = "modifySequenceLengthToolStripMenuItem";
-            this.modifySequenceLengthToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
-            this.modifySequenceLengthToolStripMenuItem.Text = "Sequence Length...";
-            this.modifySequenceLengthToolStripMenuItem.Click += new System.EventHandler(this.modifySequenceLengthToolStripMenuItem_Click);
-            // 
-            // curveEditorToolStripMenuItem
-            // 
-            this.curveEditorToolStripMenuItem.Name = "curveEditorToolStripMenuItem";
-            this.curveEditorToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
-            this.curveEditorToolStripMenuItem.Text = "Curve Editor";
-            this.curveEditorToolStripMenuItem.Click += new System.EventHandler(this.curveEditorToolStripMenuItem_Click);
-            // 
-            // colorGradientEditorToolStripMenuItem
-            // 
-            this.colorGradientEditorToolStripMenuItem.Name = "colorGradientEditorToolStripMenuItem";
-            this.colorGradientEditorToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
-            this.colorGradientEditorToolStripMenuItem.Text = "Color Gradient Editor";
-            this.colorGradientEditorToolStripMenuItem.Click += new System.EventHandler(this.colorGradientToolStripMenuItem_Click);
-            // 
-            // ColorCollectionsToolStripMenuItem
-            // 
-            this.ColorCollectionsToolStripMenuItem.Name = "ColorCollectionsToolStripMenuItem";
-            this.ColorCollectionsToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
-            this.ColorCollectionsToolStripMenuItem.Text = "Color Collection Editor";
-            this.ColorCollectionsToolStripMenuItem.Click += new System.EventHandler(this.ColorCollectionsToolStripMenuItem_Click);
-            // 
-            // lipSyncMappingsToolStripMenuItem
-            // 
-            this.lipSyncMappingsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
+			this.toolsToolStripMenuItem.Size = new System.Drawing.Size(48, 20);
+			this.toolsToolStripMenuItem.Text = "Tools";
+			// 
+			// toolStripMenuItem_associateAudio
+			// 
+			this.toolStripMenuItem_associateAudio.Name = "toolStripMenuItem_associateAudio";
+			this.toolStripMenuItem_associateAudio.Size = new System.Drawing.Size(194, 22);
+			this.toolStripMenuItem_associateAudio.Text = "Associate Audio...";
+			this.toolStripMenuItem_associateAudio.Click += new System.EventHandler(this.toolStripMenuItem_associateAudio_Click);
+			// 
+			// toolStripMenuItem_removeAudio
+			// 
+			this.toolStripMenuItem_removeAudio.Enabled = false;
+			this.toolStripMenuItem_removeAudio.Name = "toolStripMenuItem_removeAudio";
+			this.toolStripMenuItem_removeAudio.Size = new System.Drawing.Size(194, 22);
+			this.toolStripMenuItem_removeAudio.Text = "Remove Audio";
+			this.toolStripMenuItem_removeAudio.Click += new System.EventHandler(this.toolStripMenuItem_removeAudio_Click);
+			// 
+			// toolStripMenuItem_MarkManager
+			// 
+			this.toolStripMenuItem_MarkManager.Name = "toolStripMenuItem_MarkManager";
+			this.toolStripMenuItem_MarkManager.Size = new System.Drawing.Size(194, 22);
+			this.toolStripMenuItem_MarkManager.Text = "Mark Manager...";
+			this.toolStripMenuItem_MarkManager.Click += new System.EventHandler(this.toolStripMenuItem_MarkManager_Click);
+			// 
+			// modifySequenceLengthToolStripMenuItem
+			// 
+			this.modifySequenceLengthToolStripMenuItem.Name = "modifySequenceLengthToolStripMenuItem";
+			this.modifySequenceLengthToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
+			this.modifySequenceLengthToolStripMenuItem.Text = "Sequence Length...";
+			this.modifySequenceLengthToolStripMenuItem.Click += new System.EventHandler(this.modifySequenceLengthToolStripMenuItem_Click);
+			// 
+			// curveEditorToolStripMenuItem
+			// 
+			this.curveEditorToolStripMenuItem.Name = "curveEditorToolStripMenuItem";
+			this.curveEditorToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
+			this.curveEditorToolStripMenuItem.Text = "Curve Editor";
+			this.curveEditorToolStripMenuItem.Click += new System.EventHandler(this.curveEditorToolStripMenuItem_Click);
+			// 
+			// colorGradientEditorToolStripMenuItem
+			// 
+			this.colorGradientEditorToolStripMenuItem.Name = "colorGradientEditorToolStripMenuItem";
+			this.colorGradientEditorToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
+			this.colorGradientEditorToolStripMenuItem.Text = "Color Gradient Editor";
+			this.colorGradientEditorToolStripMenuItem.Click += new System.EventHandler(this.colorGradientToolStripMenuItem_Click);
+			// 
+			// ColorCollectionsToolStripMenuItem
+			// 
+			this.ColorCollectionsToolStripMenuItem.Name = "ColorCollectionsToolStripMenuItem";
+			this.ColorCollectionsToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
+			this.ColorCollectionsToolStripMenuItem.Text = "Color Collection Editor";
+			this.ColorCollectionsToolStripMenuItem.Click += new System.EventHandler(this.ColorCollectionsToolStripMenuItem_Click);
+			// 
+			// lipSyncMappingsToolStripMenuItem
+			// 
+			this.lipSyncMappingsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.defaultMapToolStripMenuItem,
             this.phonemeMappingsToolStripMenuItem,
             this.changeMapToolStripMenuItem,
             this.lyricConverterToolStripMenuItem,
             this.papagayoImportToolStripMenuItem});
-            this.lipSyncMappingsToolStripMenuItem.Name = "lipSyncMappingsToolStripMenuItem";
-            this.lipSyncMappingsToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
-            this.lipSyncMappingsToolStripMenuItem.Text = "LipSync";
-            this.lipSyncMappingsToolStripMenuItem.DropDownOpening += new System.EventHandler(this.lipSyncMappingsToolStripMenuItem_DropDownOpening);
-            // 
-            // defaultMapToolStripMenuItem
-            // 
-            this.defaultMapToolStripMenuItem.Name = "defaultMapToolStripMenuItem";
-            this.defaultMapToolStripMenuItem.Size = new System.Drawing.Size(166, 22);
-            this.defaultMapToolStripMenuItem.Text = "Default Map";
-            this.defaultMapToolStripMenuItem.DropDownOpening += new System.EventHandler(this.defaultMapToolStripMenuItem_DropDownOpening);
-            // 
-            // phonemeMappingsToolStripMenuItem
-            // 
-            this.phonemeMappingsToolStripMenuItem.Name = "phonemeMappingsToolStripMenuItem";
-            this.phonemeMappingsToolStripMenuItem.Size = new System.Drawing.Size(166, 22);
-            this.phonemeMappingsToolStripMenuItem.Text = "Edit Maps";
-            this.phonemeMappingsToolStripMenuItem.Click += new System.EventHandler(this.editMapsToolStripMenuItem_Click);
-            // 
-            // changeMapToolStripMenuItem
-            // 
-            this.changeMapToolStripMenuItem.Name = "changeMapToolStripMenuItem";
-            this.changeMapToolStripMenuItem.Size = new System.Drawing.Size(166, 22);
-            this.changeMapToolStripMenuItem.Text = "Change Effect Map";
-            this.changeMapToolStripMenuItem.DropDownOpening += new System.EventHandler(this.changeMapToolStripMenuItem_DropDownOpening);
-            // 
-            // lyricConverterToolStripMenuItem
-            // 
-            this.lyricConverterToolStripMenuItem.Name = "lyricConverterToolStripMenuItem";
-            this.lyricConverterToolStripMenuItem.Size = new System.Drawing.Size(166, 22);
-            this.lyricConverterToolStripMenuItem.Text = "Lyric Converter";
-            this.lyricConverterToolStripMenuItem.Click += new System.EventHandler(this.textConverterToolStripMenuItem_Click);
-            // 
-            // papagayoImportToolStripMenuItem
-            // 
-            this.papagayoImportToolStripMenuItem.Name = "papagayoImportToolStripMenuItem";
-            this.papagayoImportToolStripMenuItem.Size = new System.Drawing.Size(166, 22);
-            this.papagayoImportToolStripMenuItem.Text = "Papagayo Import";
-            this.papagayoImportToolStripMenuItem.Click += new System.EventHandler(this.papagayoImportToolStripMenuItem_Click);
-            // 
-            // bulkEffectMoveToolStripMenuItem
-            // 
-            this.bulkEffectMoveToolStripMenuItem.Name = "bulkEffectMoveToolStripMenuItem";
-            this.bulkEffectMoveToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
-            this.bulkEffectMoveToolStripMenuItem.Text = "Bulk Effect Move";
-            this.bulkEffectMoveToolStripMenuItem.Click += new System.EventHandler(this.bulkEffectMoveToolStripMenuItem_Click);
-            // 
-            // helpDocumentationToolStripMenuItem
-            // 
-            this.helpDocumentationToolStripMenuItem.Name = "helpDocumentationToolStripMenuItem";
-            this.helpDocumentationToolStripMenuItem.Size = new System.Drawing.Size(40, 20);
-            this.helpDocumentationToolStripMenuItem.Text = "Help";
-            this.helpDocumentationToolStripMenuItem.Click += new System.EventHandler(this.helpDocumentationToolStripMenuItem_Click);
-            // 
-            // timerPlaying
-            // 
-            this.timerPlaying.Interval = 40;
-            this.timerPlaying.Tick += new System.EventHandler(this.timerPlaying_Tick);
-            // 
-            // statusStrip
-            // 
-            this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.lipSyncMappingsToolStripMenuItem.Name = "lipSyncMappingsToolStripMenuItem";
+			this.lipSyncMappingsToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
+			this.lipSyncMappingsToolStripMenuItem.Text = "LipSync";
+			this.lipSyncMappingsToolStripMenuItem.DropDownOpening += new System.EventHandler(this.lipSyncMappingsToolStripMenuItem_DropDownOpening);
+			// 
+			// defaultMapToolStripMenuItem
+			// 
+			this.defaultMapToolStripMenuItem.Name = "defaultMapToolStripMenuItem";
+			this.defaultMapToolStripMenuItem.Size = new System.Drawing.Size(175, 22);
+			this.defaultMapToolStripMenuItem.Text = "Default Map";
+			this.defaultMapToolStripMenuItem.DropDownOpening += new System.EventHandler(this.defaultMapToolStripMenuItem_DropDownOpening);
+			// 
+			// phonemeMappingsToolStripMenuItem
+			// 
+			this.phonemeMappingsToolStripMenuItem.Name = "phonemeMappingsToolStripMenuItem";
+			this.phonemeMappingsToolStripMenuItem.Size = new System.Drawing.Size(175, 22);
+			this.phonemeMappingsToolStripMenuItem.Text = "Edit Maps";
+			this.phonemeMappingsToolStripMenuItem.Click += new System.EventHandler(this.editMapsToolStripMenuItem_Click);
+			// 
+			// changeMapToolStripMenuItem
+			// 
+			this.changeMapToolStripMenuItem.Name = "changeMapToolStripMenuItem";
+			this.changeMapToolStripMenuItem.Size = new System.Drawing.Size(175, 22);
+			this.changeMapToolStripMenuItem.Text = "Change Effect Map";
+			this.changeMapToolStripMenuItem.DropDownOpening += new System.EventHandler(this.changeMapToolStripMenuItem_DropDownOpening);
+			// 
+			// lyricConverterToolStripMenuItem
+			// 
+			this.lyricConverterToolStripMenuItem.Name = "lyricConverterToolStripMenuItem";
+			this.lyricConverterToolStripMenuItem.Size = new System.Drawing.Size(175, 22);
+			this.lyricConverterToolStripMenuItem.Text = "Lyric Converter";
+			this.lyricConverterToolStripMenuItem.Click += new System.EventHandler(this.textConverterToolStripMenuItem_Click);
+			// 
+			// papagayoImportToolStripMenuItem
+			// 
+			this.papagayoImportToolStripMenuItem.Name = "papagayoImportToolStripMenuItem";
+			this.papagayoImportToolStripMenuItem.Size = new System.Drawing.Size(175, 22);
+			this.papagayoImportToolStripMenuItem.Text = "Papagayo Import";
+			this.papagayoImportToolStripMenuItem.Click += new System.EventHandler(this.papagayoImportToolStripMenuItem_Click);
+			// 
+			// bulkEffectMoveToolStripMenuItem
+			// 
+			this.bulkEffectMoveToolStripMenuItem.Name = "bulkEffectMoveToolStripMenuItem";
+			this.bulkEffectMoveToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
+			this.bulkEffectMoveToolStripMenuItem.Text = "Bulk Effect Move";
+			this.bulkEffectMoveToolStripMenuItem.Click += new System.EventHandler(this.bulkEffectMoveToolStripMenuItem_Click);
+			// 
+			// helpDocumentationToolStripMenuItem
+			// 
+			this.helpDocumentationToolStripMenuItem.Name = "helpDocumentationToolStripMenuItem";
+			this.helpDocumentationToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
+			this.helpDocumentationToolStripMenuItem.Text = "Help";
+			this.helpDocumentationToolStripMenuItem.Click += new System.EventHandler(this.helpDocumentationToolStripMenuItem_Click);
+			// 
+			// timerPlaying
+			// 
+			this.timerPlaying.Interval = 40;
+			this.timerPlaying.Tick += new System.EventHandler(this.timerPlaying_Tick);
+			// 
+			// statusStrip
+			// 
+			this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripStatusLabel2,
             this.toolStripStatusLabel_currentTime,
             this.toolStripStatusLabel1,
@@ -1116,265 +1118,273 @@ namespace VixenModules.Editor.TimedSequenceEditor
             this.toolStripStatusLabel4,
             this.toolStripStatusLabel_RenderingElements,
             this.toolStripProgressBar_RenderingElements});
-            this.statusStrip.Location = new System.Drawing.Point(0, 585);
-            this.statusStrip.Name = "statusStrip";
-            this.statusStrip.Size = new System.Drawing.Size(1170, 24);
-            this.statusStrip.TabIndex = 4;
-            this.statusStrip.Text = "statusStrip1";
-            // 
-            // toolStripStatusLabel2
-            // 
-            this.toolStripStatusLabel2.AutoSize = false;
-            this.toolStripStatusLabel2.Name = "toolStripStatusLabel2";
-            this.toolStripStatusLabel2.Size = new System.Drawing.Size(120, 19);
-            this.toolStripStatusLabel2.Text = "Current Position:";
-            this.toolStripStatusLabel2.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // toolStripStatusLabel_currentTime
-            // 
-            this.toolStripStatusLabel_currentTime.AutoSize = false;
-            this.toolStripStatusLabel_currentTime.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Right;
-            this.toolStripStatusLabel_currentTime.BorderStyle = System.Windows.Forms.Border3DStyle.Bump;
-            this.toolStripStatusLabel_currentTime.Name = "toolStripStatusLabel_currentTime";
-            this.toolStripStatusLabel_currentTime.Size = new System.Drawing.Size(70, 19);
-            this.toolStripStatusLabel_currentTime.Text = "0:00.000";
-            this.toolStripStatusLabel_currentTime.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // toolStripStatusLabel1
-            // 
-            this.toolStripStatusLabel1.AutoSize = false;
-            this.toolStripStatusLabel1.Name = "toolStripStatusLabel1";
-            this.toolStripStatusLabel1.Size = new System.Drawing.Size(140, 19);
-            this.toolStripStatusLabel1.Text = "Sequence Length:";
-            this.toolStripStatusLabel1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // toolStripStatusLabel_sequenceLength
-            // 
-            this.toolStripStatusLabel_sequenceLength.AutoSize = false;
-            this.toolStripStatusLabel_sequenceLength.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Right;
-            this.toolStripStatusLabel_sequenceLength.BorderStyle = System.Windows.Forms.Border3DStyle.Bump;
-            this.toolStripStatusLabel_sequenceLength.Name = "toolStripStatusLabel_sequenceLength";
-            this.toolStripStatusLabel_sequenceLength.Size = new System.Drawing.Size(70, 19);
-            this.toolStripStatusLabel_sequenceLength.Text = "0:00.000";
-            this.toolStripStatusLabel_sequenceLength.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // toolStripStatusLabel3
-            // 
-            this.toolStripStatusLabel3.AutoSize = false;
-            this.toolStripStatusLabel3.ForeColor = System.Drawing.Color.Red;
-            this.toolStripStatusLabel3.Name = "toolStripStatusLabel3";
-            this.toolStripStatusLabel3.Size = new System.Drawing.Size(120, 19);
-            this.toolStripStatusLabel3.Text = "Play Delayed:";
-            this.toolStripStatusLabel3.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.toolStripStatusLabel3.Visible = false;
-            // 
-            // toolStripStatusLabel_delayPlay
-            // 
-            this.toolStripStatusLabel_delayPlay.AutoSize = false;
-            this.toolStripStatusLabel_delayPlay.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Right;
-            this.toolStripStatusLabel_delayPlay.BorderStyle = System.Windows.Forms.Border3DStyle.Bump;
-            this.toolStripStatusLabel_delayPlay.ForeColor = System.Drawing.Color.Red;
-            this.toolStripStatusLabel_delayPlay.Name = "toolStripStatusLabel_delayPlay";
-            this.toolStripStatusLabel_delayPlay.Size = new System.Drawing.Size(80, 19);
-            this.toolStripStatusLabel_delayPlay.Text = "00 Seconds";
-            this.toolStripStatusLabel_delayPlay.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.toolStripStatusLabel_delayPlay.Visible = false;
-            // 
-            // toolStripStatusLabel4
-            // 
-            this.toolStripStatusLabel4.Name = "toolStripStatusLabel4";
-            this.toolStripStatusLabel4.Size = new System.Drawing.Size(755, 19);
-            this.toolStripStatusLabel4.Spring = true;
-            // 
-            // toolStripStatusLabel_RenderingElements
-            // 
-            this.toolStripStatusLabel_RenderingElements.Name = "toolStripStatusLabel_RenderingElements";
-            this.toolStripStatusLabel_RenderingElements.Size = new System.Drawing.Size(106, 19);
-            this.toolStripStatusLabel_RenderingElements.Text = "Rendering Elements:";
-            this.toolStripStatusLabel_RenderingElements.Visible = false;
-            // 
-            // toolStripProgressBar_RenderingElements
-            // 
-            this.toolStripProgressBar_RenderingElements.Name = "toolStripProgressBar_RenderingElements";
-            this.toolStripProgressBar_RenderingElements.Size = new System.Drawing.Size(100, 18);
-            this.toolStripProgressBar_RenderingElements.Visible = false;
-            // 
-            // openFileDialog
-            // 
-            this.openFileDialog.Filter = "All files (*.*)|*.*";
-            // 
-            // toolStripContainer
-            // 
-            this.toolStripContainer.BottomToolStripPanelVisible = false;
-            // 
-            // toolStripContainer.ContentPanel
-            // 
-            this.toolStripContainer.ContentPanel.Controls.Add(this.dockPanel);
-            this.toolStripContainer.ContentPanel.Size = new System.Drawing.Size(1170, 536);
-            this.toolStripContainer.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.toolStripContainer.LeftToolStripPanelVisible = false;
-            this.toolStripContainer.Location = new System.Drawing.Point(0, 24);
-            this.toolStripContainer.Name = "toolStripContainer";
-            this.toolStripContainer.RightToolStripPanelVisible = false;
-            this.toolStripContainer.Size = new System.Drawing.Size(1170, 561);
-            this.toolStripContainer.TabIndex = 5;
-            this.toolStripContainer.Text = "toolStripContainer1";
-            // 
-            // toolStripContainer.TopToolStripPanel
-            // 
-            this.toolStripContainer.TopToolStripPanel.Controls.Add(this.toolStripOperations);
-            // 
-            // dockPanel
-            // 
-            this.dockPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.dockPanel.DockLeftPortion = 200D;
-            this.dockPanel.DocumentStyle = WeifenLuo.WinFormsUI.Docking.DocumentStyle.DockingWindow;
-            this.dockPanel.Location = new System.Drawing.Point(0, 0);
-            this.dockPanel.Name = "dockPanel";
-            this.dockPanel.Size = new System.Drawing.Size(1170, 536);
-            dockPanelGradient1.EndColor = System.Drawing.SystemColors.ControlLight;
-            dockPanelGradient1.StartColor = System.Drawing.SystemColors.ControlLight;
-            autoHideStripSkin1.DockStripGradient = dockPanelGradient1;
-            tabGradient1.EndColor = System.Drawing.SystemColors.Control;
-            tabGradient1.StartColor = System.Drawing.SystemColors.Control;
-            tabGradient1.TextColor = System.Drawing.SystemColors.ControlDarkDark;
-            autoHideStripSkin1.TabGradient = tabGradient1;
-            autoHideStripSkin1.TextFont = new System.Drawing.Font("Segoe UI", 9F);
-            dockPanelSkin1.AutoHideStripSkin = autoHideStripSkin1;
-            tabGradient2.EndColor = System.Drawing.SystemColors.ControlLightLight;
-            tabGradient2.StartColor = System.Drawing.SystemColors.ControlLightLight;
-            tabGradient2.TextColor = System.Drawing.SystemColors.ControlText;
-            dockPaneStripGradient1.ActiveTabGradient = tabGradient2;
-            dockPanelGradient2.EndColor = System.Drawing.SystemColors.Control;
-            dockPanelGradient2.StartColor = System.Drawing.SystemColors.Control;
-            dockPaneStripGradient1.DockStripGradient = dockPanelGradient2;
-            tabGradient3.EndColor = System.Drawing.SystemColors.ControlLight;
-            tabGradient3.StartColor = System.Drawing.SystemColors.ControlLight;
-            tabGradient3.TextColor = System.Drawing.SystemColors.ControlText;
-            dockPaneStripGradient1.InactiveTabGradient = tabGradient3;
-            dockPaneStripSkin1.DocumentGradient = dockPaneStripGradient1;
-            dockPaneStripSkin1.TextFont = new System.Drawing.Font("Segoe UI", 9F);
-            tabGradient4.EndColor = System.Drawing.SystemColors.ActiveCaption;
-            tabGradient4.LinearGradientMode = System.Drawing.Drawing2D.LinearGradientMode.Vertical;
-            tabGradient4.StartColor = System.Drawing.SystemColors.GradientActiveCaption;
-            tabGradient4.TextColor = System.Drawing.SystemColors.ActiveCaptionText;
-            dockPaneStripToolWindowGradient1.ActiveCaptionGradient = tabGradient4;
-            tabGradient5.EndColor = System.Drawing.SystemColors.Control;
-            tabGradient5.StartColor = System.Drawing.SystemColors.Control;
-            tabGradient5.TextColor = System.Drawing.SystemColors.ControlText;
-            dockPaneStripToolWindowGradient1.ActiveTabGradient = tabGradient5;
-            dockPanelGradient3.EndColor = System.Drawing.SystemColors.ControlLight;
-            dockPanelGradient3.StartColor = System.Drawing.SystemColors.ControlLight;
-            dockPaneStripToolWindowGradient1.DockStripGradient = dockPanelGradient3;
-            tabGradient6.EndColor = System.Drawing.SystemColors.InactiveCaption;
-            tabGradient6.LinearGradientMode = System.Drawing.Drawing2D.LinearGradientMode.Vertical;
-            tabGradient6.StartColor = System.Drawing.SystemColors.GradientInactiveCaption;
-            tabGradient6.TextColor = System.Drawing.SystemColors.InactiveCaptionText;
-            dockPaneStripToolWindowGradient1.InactiveCaptionGradient = tabGradient6;
-            tabGradient7.EndColor = System.Drawing.Color.Transparent;
-            tabGradient7.StartColor = System.Drawing.Color.Transparent;
-            tabGradient7.TextColor = System.Drawing.SystemColors.ControlDarkDark;
-            dockPaneStripToolWindowGradient1.InactiveTabGradient = tabGradient7;
-            dockPaneStripSkin1.ToolWindowGradient = dockPaneStripToolWindowGradient1;
-            dockPanelSkin1.DockPaneStripSkin = dockPaneStripSkin1;
-            this.dockPanel.Skin = dockPanelSkin1;
-            this.dockPanel.TabIndex = 13;
-            // 
-            // toolStripExVirtualEffects
-            // 
-            this.toolStripExVirtualEffects.ClickThrough = true;
-            this.toolStripExVirtualEffects.Dock = System.Windows.Forms.DockStyle.None;
-            this.toolStripExVirtualEffects.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.statusStrip.Location = new System.Drawing.Point(0, 585);
+			this.statusStrip.Name = "statusStrip";
+			this.statusStrip.Size = new System.Drawing.Size(1170, 24);
+			this.statusStrip.TabIndex = 4;
+			this.statusStrip.Text = "statusStrip1";
+			// 
+			// toolStripStatusLabel2
+			// 
+			this.toolStripStatusLabel2.AutoSize = false;
+			this.toolStripStatusLabel2.Name = "toolStripStatusLabel2";
+			this.toolStripStatusLabel2.Size = new System.Drawing.Size(120, 19);
+			this.toolStripStatusLabel2.Text = "Current Position:";
+			this.toolStripStatusLabel2.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// toolStripStatusLabel_currentTime
+			// 
+			this.toolStripStatusLabel_currentTime.AutoSize = false;
+			this.toolStripStatusLabel_currentTime.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Right;
+			this.toolStripStatusLabel_currentTime.BorderStyle = System.Windows.Forms.Border3DStyle.Bump;
+			this.toolStripStatusLabel_currentTime.Name = "toolStripStatusLabel_currentTime";
+			this.toolStripStatusLabel_currentTime.Size = new System.Drawing.Size(70, 19);
+			this.toolStripStatusLabel_currentTime.Text = "0:00.000";
+			this.toolStripStatusLabel_currentTime.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// toolStripStatusLabel1
+			// 
+			this.toolStripStatusLabel1.AutoSize = false;
+			this.toolStripStatusLabel1.Name = "toolStripStatusLabel1";
+			this.toolStripStatusLabel1.Size = new System.Drawing.Size(140, 19);
+			this.toolStripStatusLabel1.Text = "Sequence Length:";
+			this.toolStripStatusLabel1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// toolStripStatusLabel_sequenceLength
+			// 
+			this.toolStripStatusLabel_sequenceLength.AutoSize = false;
+			this.toolStripStatusLabel_sequenceLength.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Right;
+			this.toolStripStatusLabel_sequenceLength.BorderStyle = System.Windows.Forms.Border3DStyle.Bump;
+			this.toolStripStatusLabel_sequenceLength.Name = "toolStripStatusLabel_sequenceLength";
+			this.toolStripStatusLabel_sequenceLength.Size = new System.Drawing.Size(70, 19);
+			this.toolStripStatusLabel_sequenceLength.Text = "0:00.000";
+			this.toolStripStatusLabel_sequenceLength.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
+			// toolStripStatusLabel3
+			// 
+			this.toolStripStatusLabel3.AutoSize = false;
+			this.toolStripStatusLabel3.ForeColor = System.Drawing.Color.Red;
+			this.toolStripStatusLabel3.Name = "toolStripStatusLabel3";
+			this.toolStripStatusLabel3.Size = new System.Drawing.Size(120, 19);
+			this.toolStripStatusLabel3.Text = "Play Delayed:";
+			this.toolStripStatusLabel3.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			this.toolStripStatusLabel3.Visible = false;
+			// 
+			// toolStripStatusLabel_delayPlay
+			// 
+			this.toolStripStatusLabel_delayPlay.AutoSize = false;
+			this.toolStripStatusLabel_delayPlay.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Right;
+			this.toolStripStatusLabel_delayPlay.BorderStyle = System.Windows.Forms.Border3DStyle.Bump;
+			this.toolStripStatusLabel_delayPlay.ForeColor = System.Drawing.Color.Red;
+			this.toolStripStatusLabel_delayPlay.Name = "toolStripStatusLabel_delayPlay";
+			this.toolStripStatusLabel_delayPlay.Size = new System.Drawing.Size(80, 19);
+			this.toolStripStatusLabel_delayPlay.Text = "00 Seconds";
+			this.toolStripStatusLabel_delayPlay.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			this.toolStripStatusLabel_delayPlay.Visible = false;
+			// 
+			// toolStripStatusLabel4
+			// 
+			this.toolStripStatusLabel4.Name = "toolStripStatusLabel4";
+			this.toolStripStatusLabel4.Size = new System.Drawing.Size(755, 19);
+			this.toolStripStatusLabel4.Spring = true;
+			// 
+			// toolStripStatusLabel_RenderingElements
+			// 
+			this.toolStripStatusLabel_RenderingElements.Name = "toolStripStatusLabel_RenderingElements";
+			this.toolStripStatusLabel_RenderingElements.Size = new System.Drawing.Size(115, 19);
+			this.toolStripStatusLabel_RenderingElements.Text = "Rendering Elements:";
+			this.toolStripStatusLabel_RenderingElements.Visible = false;
+			// 
+			// toolStripProgressBar_RenderingElements
+			// 
+			this.toolStripProgressBar_RenderingElements.Name = "toolStripProgressBar_RenderingElements";
+			this.toolStripProgressBar_RenderingElements.Size = new System.Drawing.Size(100, 18);
+			this.toolStripProgressBar_RenderingElements.Visible = false;
+			// 
+			// openFileDialog
+			// 
+			this.openFileDialog.Filter = "All files (*.*)|*.*";
+			// 
+			// toolStripContainer
+			// 
+			this.toolStripContainer.BottomToolStripPanelVisible = false;
+			// 
+			// toolStripContainer.ContentPanel
+			// 
+			this.toolStripContainer.ContentPanel.Controls.Add(this.dockPanel);
+			this.toolStripContainer.ContentPanel.Size = new System.Drawing.Size(1170, 534);
+			this.toolStripContainer.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.toolStripContainer.LeftToolStripPanelVisible = false;
+			this.toolStripContainer.Location = new System.Drawing.Point(0, 24);
+			this.toolStripContainer.Name = "toolStripContainer";
+			this.toolStripContainer.RightToolStripPanelVisible = false;
+			this.toolStripContainer.Size = new System.Drawing.Size(1170, 561);
+			this.toolStripContainer.TabIndex = 5;
+			this.toolStripContainer.Text = "toolStripContainer1";
+			// 
+			// toolStripContainer.TopToolStripPanel
+			// 
+			this.toolStripContainer.TopToolStripPanel.Controls.Add(this.toolStripOperations);
+			// 
+			// dockPanel
+			// 
+			this.dockPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.dockPanel.DockLeftPortion = 200D;
+			this.dockPanel.DocumentStyle = WeifenLuo.WinFormsUI.Docking.DocumentStyle.DockingWindow;
+			this.dockPanel.Location = new System.Drawing.Point(0, 0);
+			this.dockPanel.Name = "dockPanel";
+			this.dockPanel.Size = new System.Drawing.Size(1170, 534);
+			dockPanelGradient4.EndColor = System.Drawing.SystemColors.ControlLight;
+			dockPanelGradient4.StartColor = System.Drawing.SystemColors.ControlLight;
+			autoHideStripSkin2.DockStripGradient = dockPanelGradient4;
+			tabGradient8.EndColor = System.Drawing.SystemColors.Control;
+			tabGradient8.StartColor = System.Drawing.SystemColors.Control;
+			tabGradient8.TextColor = System.Drawing.SystemColors.ControlDarkDark;
+			autoHideStripSkin2.TabGradient = tabGradient8;
+			autoHideStripSkin2.TextFont = new System.Drawing.Font("Segoe UI", 9F);
+			dockPanelSkin2.AutoHideStripSkin = autoHideStripSkin2;
+			tabGradient9.EndColor = System.Drawing.SystemColors.ControlLightLight;
+			tabGradient9.StartColor = System.Drawing.SystemColors.ControlLightLight;
+			tabGradient9.TextColor = System.Drawing.SystemColors.ControlText;
+			dockPaneStripGradient2.ActiveTabGradient = tabGradient9;
+			dockPanelGradient5.EndColor = System.Drawing.SystemColors.Control;
+			dockPanelGradient5.StartColor = System.Drawing.SystemColors.Control;
+			dockPaneStripGradient2.DockStripGradient = dockPanelGradient5;
+			tabGradient10.EndColor = System.Drawing.SystemColors.ControlLight;
+			tabGradient10.StartColor = System.Drawing.SystemColors.ControlLight;
+			tabGradient10.TextColor = System.Drawing.SystemColors.ControlText;
+			dockPaneStripGradient2.InactiveTabGradient = tabGradient10;
+			dockPaneStripSkin2.DocumentGradient = dockPaneStripGradient2;
+			dockPaneStripSkin2.TextFont = new System.Drawing.Font("Segoe UI", 9F);
+			tabGradient11.EndColor = System.Drawing.SystemColors.ActiveCaption;
+			tabGradient11.LinearGradientMode = System.Drawing.Drawing2D.LinearGradientMode.Vertical;
+			tabGradient11.StartColor = System.Drawing.SystemColors.GradientActiveCaption;
+			tabGradient11.TextColor = System.Drawing.SystemColors.ActiveCaptionText;
+			dockPaneStripToolWindowGradient2.ActiveCaptionGradient = tabGradient11;
+			tabGradient12.EndColor = System.Drawing.SystemColors.Control;
+			tabGradient12.StartColor = System.Drawing.SystemColors.Control;
+			tabGradient12.TextColor = System.Drawing.SystemColors.ControlText;
+			dockPaneStripToolWindowGradient2.ActiveTabGradient = tabGradient12;
+			dockPanelGradient6.EndColor = System.Drawing.SystemColors.ControlLight;
+			dockPanelGradient6.StartColor = System.Drawing.SystemColors.ControlLight;
+			dockPaneStripToolWindowGradient2.DockStripGradient = dockPanelGradient6;
+			tabGradient13.EndColor = System.Drawing.SystemColors.InactiveCaption;
+			tabGradient13.LinearGradientMode = System.Drawing.Drawing2D.LinearGradientMode.Vertical;
+			tabGradient13.StartColor = System.Drawing.SystemColors.GradientInactiveCaption;
+			tabGradient13.TextColor = System.Drawing.SystemColors.InactiveCaptionText;
+			dockPaneStripToolWindowGradient2.InactiveCaptionGradient = tabGradient13;
+			tabGradient14.EndColor = System.Drawing.Color.Transparent;
+			tabGradient14.StartColor = System.Drawing.Color.Transparent;
+			tabGradient14.TextColor = System.Drawing.SystemColors.ControlDarkDark;
+			dockPaneStripToolWindowGradient2.InactiveTabGradient = tabGradient14;
+			dockPaneStripSkin2.ToolWindowGradient = dockPaneStripToolWindowGradient2;
+			dockPanelSkin2.DockPaneStripSkin = dockPaneStripSkin2;
+			this.dockPanel.Skin = dockPanelSkin2;
+			this.dockPanel.TabIndex = 13;
+			// 
+			// toolStripExVirtualEffects
+			// 
+			this.toolStripExVirtualEffects.ClickThrough = true;
+			this.toolStripExVirtualEffects.Dock = System.Windows.Forms.DockStyle.None;
+			this.toolStripExVirtualEffects.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripLabelVirtualEffects,
             this.toolStripButtonVirtualEffectsAdd,
             this.toolStripButtonVirtualEffectsRemove,
             this.toolStripSeparatorBeginEffects});
-            this.toolStripExVirtualEffects.Location = new System.Drawing.Point(3, 75);
-            this.toolStripExVirtualEffects.Name = "toolStripExVirtualEffects";
-            this.toolStripExVirtualEffects.Size = new System.Drawing.Size(156, 25);
-            this.toolStripExVirtualEffects.TabIndex = 7;
-            // 
-            // toolStripLabelVirtualEffects
-            // 
-            this.toolStripLabelVirtualEffects.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripLabelVirtualEffects.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.toolStripLabelVirtualEffects.Name = "toolStripLabelVirtualEffects";
-            this.toolStripLabelVirtualEffects.Size = new System.Drawing.Size(92, 22);
-            this.toolStripLabelVirtualEffects.Text = "Virtual Effects: ";
-            // 
-            // toolStripButtonVirtualEffectsAdd
-            // 
-            this.toolStripButtonVirtualEffectsAdd.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripButtonVirtualEffectsAdd.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripButtonVirtualEffectsAdd.Name = "toolStripButtonVirtualEffectsAdd";
-            this.toolStripButtonVirtualEffectsAdd.Size = new System.Drawing.Size(23, 22);
-            this.toolStripButtonVirtualEffectsAdd.Text = "+";
-            this.toolStripButtonVirtualEffectsAdd.Click += new System.EventHandler(this.toolStripButtonVirtualEffectsAdd_Click);
-            // 
-            // toolStripButtonVirtualEffectsRemove
-            // 
-            this.toolStripButtonVirtualEffectsRemove.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripButtonVirtualEffectsRemove.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripButtonVirtualEffectsRemove.Name = "toolStripButtonVirtualEffectsRemove";
-            this.toolStripButtonVirtualEffectsRemove.Size = new System.Drawing.Size(23, 22);
-            this.toolStripButtonVirtualEffectsRemove.Text = "-";
-            this.toolStripButtonVirtualEffectsRemove.Click += new System.EventHandler(this.toolStripButtonVirtualEffectsRemove_Click);
-            // 
-            // toolStripSeparatorBeginEffects
-            // 
-            this.toolStripSeparatorBeginEffects.Name = "toolStripSeparatorBeginEffects";
-            this.toolStripSeparatorBeginEffects.Size = new System.Drawing.Size(6, 25);
-            // 
-            // saveFileDialog
-            // 
-            this.saveFileDialog.Title = "Save timed sequence";
-            // 
-            // contextMenuStripElementSelection
-            // 
-            this.contextMenuStripElementSelection.Name = "contextMenuStripElementSelection";
-            this.contextMenuStripElementSelection.Size = new System.Drawing.Size(61, 4);
-            // 
-            // timerPostponePlay
-            // 
-            this.timerPostponePlay.Tick += new System.EventHandler(this.timerPostponePlay_Tick);
-            // 
-            // timerDelayCountdown
-            // 
-            this.timerDelayCountdown.Interval = 1000;
-            this.timerDelayCountdown.Tick += new System.EventHandler(this.timerDelayCountdown_Tick);
-            // 
-            // TimedSequenceEditorForm
-            // 
-            this.AllowDrop = true;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1170, 609);
-            this.Controls.Add(this.toolStripContainer);
-            this.Controls.Add(this.statusStrip);
-            this.Controls.Add(this.menuStrip);
-            this.DoubleBuffered = true;
-            this.KeyPreview = true;
-            this.MainMenuStrip = this.menuStrip;
-            this.Name = "TimedSequenceEditorForm";
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "Timed Sequence Editor";
-            this.Load += new System.EventHandler(this.TimedSequenceEditorForm_Load);
-            this.Shown += new System.EventHandler(this.TimedSequenceEditorForm_Shown);
-            this.toolStripOperations.ResumeLayout(false);
-            this.toolStripOperations.PerformLayout();
-            this.menuStrip.ResumeLayout(false);
-            this.menuStrip.PerformLayout();
-            this.statusStrip.ResumeLayout(false);
-            this.statusStrip.PerformLayout();
-            this.toolStripContainer.ContentPanel.ResumeLayout(false);
-            this.toolStripContainer.TopToolStripPanel.ResumeLayout(false);
-            this.toolStripContainer.TopToolStripPanel.PerformLayout();
-            this.toolStripContainer.ResumeLayout(false);
-            this.toolStripContainer.PerformLayout();
-            this.toolStripExVirtualEffects.ResumeLayout(false);
-            this.toolStripExVirtualEffects.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
+			this.toolStripExVirtualEffects.Location = new System.Drawing.Point(3, 75);
+			this.toolStripExVirtualEffects.Name = "toolStripExVirtualEffects";
+			this.toolStripExVirtualEffects.Size = new System.Drawing.Size(156, 25);
+			this.toolStripExVirtualEffects.TabIndex = 7;
+			// 
+			// toolStripLabelVirtualEffects
+			// 
+			this.toolStripLabelVirtualEffects.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.toolStripLabelVirtualEffects.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.toolStripLabelVirtualEffects.Name = "toolStripLabelVirtualEffects";
+			this.toolStripLabelVirtualEffects.Size = new System.Drawing.Size(92, 22);
+			this.toolStripLabelVirtualEffects.Text = "Virtual Effects: ";
+			// 
+			// toolStripButtonVirtualEffectsAdd
+			// 
+			this.toolStripButtonVirtualEffectsAdd.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.toolStripButtonVirtualEffectsAdd.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.toolStripButtonVirtualEffectsAdd.Name = "toolStripButtonVirtualEffectsAdd";
+			this.toolStripButtonVirtualEffectsAdd.Size = new System.Drawing.Size(23, 22);
+			this.toolStripButtonVirtualEffectsAdd.Text = "+";
+			this.toolStripButtonVirtualEffectsAdd.Click += new System.EventHandler(this.toolStripButtonVirtualEffectsAdd_Click);
+			// 
+			// toolStripButtonVirtualEffectsRemove
+			// 
+			this.toolStripButtonVirtualEffectsRemove.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.toolStripButtonVirtualEffectsRemove.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.toolStripButtonVirtualEffectsRemove.Name = "toolStripButtonVirtualEffectsRemove";
+			this.toolStripButtonVirtualEffectsRemove.Size = new System.Drawing.Size(23, 22);
+			this.toolStripButtonVirtualEffectsRemove.Text = "-";
+			this.toolStripButtonVirtualEffectsRemove.Click += new System.EventHandler(this.toolStripButtonVirtualEffectsRemove_Click);
+			// 
+			// toolStripSeparatorBeginEffects
+			// 
+			this.toolStripSeparatorBeginEffects.Name = "toolStripSeparatorBeginEffects";
+			this.toolStripSeparatorBeginEffects.Size = new System.Drawing.Size(6, 25);
+			// 
+			// saveFileDialog
+			// 
+			this.saveFileDialog.Title = "Save timed sequence";
+			// 
+			// contextMenuStripElementSelection
+			// 
+			this.contextMenuStripElementSelection.Name = "contextMenuStripElementSelection";
+			this.contextMenuStripElementSelection.Size = new System.Drawing.Size(61, 4);
+			// 
+			// timerPostponePlay
+			// 
+			this.timerPostponePlay.Tick += new System.EventHandler(this.timerPostponePlay_Tick);
+			// 
+			// timerDelayCountdown
+			// 
+			this.timerDelayCountdown.Interval = 1000;
+			this.timerDelayCountdown.Tick += new System.EventHandler(this.timerDelayCountdown_Tick);
+			// 
+			// cADStyleSelectionBoxToolStripMenuItem
+			// 
+			this.cADStyleSelectionBoxToolStripMenuItem.CheckOnClick = true;
+			this.cADStyleSelectionBoxToolStripMenuItem.Name = "cADStyleSelectionBoxToolStripMenuItem";
+			this.cADStyleSelectionBoxToolStripMenuItem.Size = new System.Drawing.Size(215, 22);
+			this.cADStyleSelectionBoxToolStripMenuItem.Text = "CAD Style Selection Box";
+			this.cADStyleSelectionBoxToolStripMenuItem.Click += new System.EventHandler(this.cADStyleSelectionBoxToolStripMenuItem_Click);
+			// 
+			// TimedSequenceEditorForm
+			// 
+			this.AllowDrop = true;
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(1170, 609);
+			this.Controls.Add(this.toolStripContainer);
+			this.Controls.Add(this.statusStrip);
+			this.Controls.Add(this.menuStrip);
+			this.DoubleBuffered = true;
+			this.KeyPreview = true;
+			this.MainMenuStrip = this.menuStrip;
+			this.Name = "TimedSequenceEditorForm";
+			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+			this.Text = "Timed Sequence Editor";
+			this.Load += new System.EventHandler(this.TimedSequenceEditorForm_Load);
+			this.Shown += new System.EventHandler(this.TimedSequenceEditorForm_Shown);
+			this.toolStripOperations.ResumeLayout(false);
+			this.toolStripOperations.PerformLayout();
+			this.menuStrip.ResumeLayout(false);
+			this.menuStrip.PerformLayout();
+			this.statusStrip.ResumeLayout(false);
+			this.statusStrip.PerformLayout();
+			this.toolStripContainer.ContentPanel.ResumeLayout(false);
+			this.toolStripContainer.TopToolStripPanel.ResumeLayout(false);
+			this.toolStripContainer.TopToolStripPanel.PerformLayout();
+			this.toolStripContainer.ResumeLayout(false);
+			this.toolStripContainer.PerformLayout();
+			this.toolStripExVirtualEffects.ResumeLayout(false);
+			this.toolStripExVirtualEffects.PerformLayout();
+			this.ResumeLayout(false);
+			this.PerformLayout();
 
 		}
 
@@ -1507,5 +1517,6 @@ namespace VixenModules.Editor.TimedSequenceEditor
 		private System.Windows.Forms.ToolStripMenuItem toolWindowToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem helpDocumentationToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem bulkEffectMoveToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem cADStyleSelectionBoxToolStripMenuItem;
 	}
 }

--- a/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
+++ b/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
@@ -229,7 +229,7 @@ namespace VixenModules.Editor.TimedSequenceEditor
 			toolStripButton_SelectionMode.Checked = xml.GetSetting(XMLProfileSettings.SettingType.AppSettings, string.Format("{0}/SelectionModeSelected", Name), true);
 			ToolsForm.LinkCurves = xml.GetSetting(XMLProfileSettings.SettingType.AppSettings, string.Format("{0}/ToolPaletteLinkCurves", Name), false);
 			ToolsForm.LinkGradients = xml.GetSetting(XMLProfileSettings.SettingType.AppSettings, string.Format("{0}/ToolPaletteLinkGradients", Name), false);
-
+			cADStyleSelectionBoxToolStripMenuItem.Checked = TimelineControl.grid.aCadStyleSelectionBox = xml.GetSetting(XMLProfileSettings.SettingType.AppSettings, string.Format("{0}/CadStyleSelectionBox", Name), false);
 			CheckRiColorMenuItem(xml.GetSetting(XMLProfileSettings.SettingType.AppSettings, string.Format("{0}/ResizeIndicatorColor", Name), "Red"));
 
 			foreach (ToolStripItem toolStripItem in toolStripDropDownButton_SnapToStrength.DropDownItems)
@@ -4015,6 +4015,7 @@ namespace VixenModules.Editor.TimedSequenceEditor
 			xml.PutSetting(XMLProfileSettings.SettingType.AppSettings, string.Format("{0}/WindowState", Name), WindowState.ToString());
 			xml.PutSetting(XMLProfileSettings.SettingType.AppSettings, string.Format("{0}/SnapStrength", Name), TimelineControl.grid.SnapStrength);
 			xml.PutSetting(XMLProfileSettings.SettingType.AppSettings, string.Format("{0}/ResizeIndicatorEnabled", Name), TimelineControl.grid.ResizeIndicator_Enabled);
+			xml.PutSetting(XMLProfileSettings.SettingType.AppSettings, string.Format("{0}/CadStyleSelectionBox", Name), cADStyleSelectionBoxToolStripMenuItem.Checked);
 			xml.PutSetting(XMLProfileSettings.SettingType.AppSettings, string.Format("{0}/ResizeIndicatorColor", Name), TimelineControl.grid.ResizeIndicator_Color);
 			xml.PutSetting(XMLProfileSettings.SettingType.AppSettings, string.Format("{0}/ToolPaletteLinkCurves", Name), ToolsForm.LinkCurves);
 			xml.PutSetting(XMLProfileSettings.SettingType.AppSettings, string.Format("{0}/ToolPaletteLinkGradients", Name), ToolsForm.LinkGradients);
@@ -4584,6 +4585,11 @@ namespace VixenModules.Editor.TimedSequenceEditor
 					TimelineControl.grid.MoveElementsInRangeByTime(dialog.Start, dialog.End, dialog.IsForward?dialog.Offset:-dialog.Offset);
 				}
 			}
+		}
+
+		private void cADStyleSelectionBoxToolStripMenuItem_Click(object sender, EventArgs e)
+		{
+			TimelineControl.grid.aCadStyleSelectionBox = cADStyleSelectionBoxToolStripMenuItem.Checked;
 		}
 
 


### PR DESCRIPTION
When ON:
Dragging right to left selections any effects within the box.
Dragging left to right only selects effects that are contained in the box in whole.

This is per Derek's request (VIX-617)
