### PR TITLE
Adds missing call to sequenceModified()

### DIFF
--- a/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
+++ b/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
@@ -3684,6 +3684,7 @@ namespace VixenModules.Editor.TimedSequenceEditor
 				if (success)
 				{
 					SequenceLength = time;
+					sequenceModified();
 					break;
 				}
 				else


### PR DESCRIPTION
Adds missing call to sequenceModified() when changing the length of the sequence from the Tools menu.

For VIX-635
