### PR TITLE
Merge vix 913

### DIFF
--- a/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.Designer.cs
+++ b/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.Designer.cs
@@ -18,173 +18,175 @@ namespace VixenModules.Editor.TimedSequenceEditor
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.components = new System.ComponentModel.Container();
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(TimedSequenceEditorForm));
-			WeifenLuo.WinFormsUI.Docking.DockPanelSkin dockPanelSkin1 = new WeifenLuo.WinFormsUI.Docking.DockPanelSkin();
-			WeifenLuo.WinFormsUI.Docking.AutoHideStripSkin autoHideStripSkin1 = new WeifenLuo.WinFormsUI.Docking.AutoHideStripSkin();
-			WeifenLuo.WinFormsUI.Docking.DockPanelGradient dockPanelGradient1 = new WeifenLuo.WinFormsUI.Docking.DockPanelGradient();
-			WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient1 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
-			WeifenLuo.WinFormsUI.Docking.DockPaneStripSkin dockPaneStripSkin1 = new WeifenLuo.WinFormsUI.Docking.DockPaneStripSkin();
-			WeifenLuo.WinFormsUI.Docking.DockPaneStripGradient dockPaneStripGradient1 = new WeifenLuo.WinFormsUI.Docking.DockPaneStripGradient();
-			WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient2 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
-			WeifenLuo.WinFormsUI.Docking.DockPanelGradient dockPanelGradient2 = new WeifenLuo.WinFormsUI.Docking.DockPanelGradient();
-			WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient3 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
-			WeifenLuo.WinFormsUI.Docking.DockPaneStripToolWindowGradient dockPaneStripToolWindowGradient1 = new WeifenLuo.WinFormsUI.Docking.DockPaneStripToolWindowGradient();
-			WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient4 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
-			WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient5 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
-			WeifenLuo.WinFormsUI.Docking.DockPanelGradient dockPanelGradient3 = new WeifenLuo.WinFormsUI.Docking.DockPanelGradient();
-			WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient6 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
-			WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient7 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
-			this.toolStripOperations = new Common.Controls.ToolStripEx();
-			this.toolStripButton_Start = new System.Windows.Forms.ToolStripButton();
-			this.toolStripButton_Play = new System.Windows.Forms.ToolStripButton();
-			this.toolStripButton_Stop = new System.Windows.Forms.ToolStripButton();
-			this.toolStripButton_Pause = new System.Windows.Forms.ToolStripButton();
-			this.toolStripButton_End = new System.Windows.Forms.ToolStripButton();
-			this.toolStripButton_Loop = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
-			this.undoButton = new Common.Controls.UndoButton();
-			this.redoButton = new Common.Controls.UndoButton();
-			this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
-			this.toolStripButton_Cut = new System.Windows.Forms.ToolStripButton();
-			this.toolStripButton_Copy = new System.Windows.Forms.ToolStripButton();
-			this.toolStripButton_Paste = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
-			this.toolStripButton_AssociateAudio = new System.Windows.Forms.ToolStripButton();
-			this.toolStripButton_MarkManager = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator13 = new System.Windows.Forms.ToolStripSeparator();
-			this.toolStripButton_ZoomTimeIn = new System.Windows.Forms.ToolStripButton();
-			this.toolStripButton_ZoomTimeOut = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
-			this.toolStripButton_DrawMode = new System.Windows.Forms.ToolStripButton();
-			this.toolStripButton_SelectionMode = new System.Windows.Forms.ToolStripButton();
-			this.toolStripButton_SnapTo = new System.Windows.Forms.ToolStripButton();
-			this.toolStripDropDownButton_SnapToStrength = new System.Windows.Forms.ToolStripDropDownButton();
-			this.toolStripMenuItem_SnapStrength_1 = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_SnapStrength_2 = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_SnapStrength_3 = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_SnapStrength_4 = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripButton_DragBoxFilter = new System.Windows.Forms.ToolStripButton();
-			this.toolStripDropDownButton_DragBoxFilter = new System.Windows.Forms.ToolStripDropDownButton();
-			this.toolStripSplitButton_CloseGaps = new System.Windows.Forms.ToolStripSplitButton();
-			this.toolStripMenuItem_CloseGap100 = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_CloseGap200 = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_CloseGap300 = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_CloseGap400 = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
-			this.toolStripLabel_TimingSpeedLabel = new System.Windows.Forms.ToolStripLabel();
-			this.toolStripLabel_TimingSpeed = new System.Windows.Forms.ToolStripLabel();
-			this.toolStripButton_IncreaseTimingSpeed = new System.Windows.Forms.ToolStripButton();
-			this.toolStripButton_DecreaseTimingSpeed = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator12 = new System.Windows.Forms.ToolStripSeparator();
-			this.toolStripLabel3 = new System.Windows.Forms.ToolStripLabel();
-			this.cboAudioDevices = new System.Windows.Forms.ToolStripComboBox();
-			this.menuStrip = new Common.Controls.MenuStripEx();
-			this.sequenceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_Save = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_SaveAs = new System.Windows.Forms.ToolStripMenuItem();
-			this.autoSaveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator15 = new System.Windows.Forms.ToolStripSeparator();
-			this.playbackToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.playToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.pauseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.stopToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_Loop = new System.Windows.Forms.ToolStripMenuItem();
-			this.playOptionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.delayOffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.delay5SecondsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.delay10SecondsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.delay20SecondsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.delay30SecondsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.delay60SecondsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator16 = new System.Windows.Forms.ToolStripSeparator();
-			this.exportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.toolStripMenuItem_Close = new System.Windows.Forms.ToolStripMenuItem();
-			this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.addEffectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-			this.toolStripMenuItem_Cut = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_Copy = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_Paste = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
-			this.undoToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.redoToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-			this.selectAllElementsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_deleteElements = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
-			this.toolStripMenuItem_SnapTo = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_ResizeIndicator = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_RIColor_Blue = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_RIColor_Yellow = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_RIColor_Green = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_RIColor_White = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_RIColor_Red = new System.Windows.Forms.ToolStripMenuItem();
-			this.cADStyleSelectionBoxToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.viewToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_zoomTimeIn = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_zoomTimeOut = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_zoomRowsIn = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_zoomRowsOut = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
-			this.effectWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.markWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.gridWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.effectEditorWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.audioToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_associateAudio = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_removeAudio = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
-			this.beatBarDetectionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem_MarkManager = new System.Windows.Forms.ToolStripMenuItem();
-			this.modifySequenceLengthToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.curveEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.colorGradientEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ColorCollectionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.lipSyncMappingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.defaultMapToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.phonemeMappingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.changeMapToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.lyricConverterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.papagayoImportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.bulkEffectMoveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.helpDocumentationToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.timerPlaying = new System.Windows.Forms.Timer(this.components);
-			this.statusStrip = new System.Windows.Forms.StatusStrip();
-			this.toolStripStatusLabel2 = new System.Windows.Forms.ToolStripStatusLabel();
-			this.toolStripStatusLabel_currentTime = new System.Windows.Forms.ToolStripStatusLabel();
-			this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
-			this.toolStripStatusLabel_sequenceLength = new System.Windows.Forms.ToolStripStatusLabel();
-			this.toolStripStatusLabel3 = new System.Windows.Forms.ToolStripStatusLabel();
-			this.toolStripStatusLabel_delayPlay = new System.Windows.Forms.ToolStripStatusLabel();
-			this.toolStripStatusLabel4 = new System.Windows.Forms.ToolStripStatusLabel();
-			this.toolStripStatusLabel_RenderingElements = new System.Windows.Forms.ToolStripStatusLabel();
-			this.toolStripProgressBar_RenderingElements = new System.Windows.Forms.ToolStripProgressBar();
-			this.openFileDialog = new System.Windows.Forms.OpenFileDialog();
-			this.toolStripContainer = new System.Windows.Forms.ToolStripContainer();
-			this.dockPanel = new WeifenLuo.WinFormsUI.Docking.DockPanel();
-			this.saveFileDialog = new System.Windows.Forms.SaveFileDialog();
-			this.contextMenuStripElementSelection = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.timerPostponePlay = new System.Windows.Forms.Timer(this.components);
-			this.timerDelayCountdown = new System.Windows.Forms.Timer(this.components);
-			this.toolStripOperations.SuspendLayout();
-			this.menuStrip.SuspendLayout();
-			this.statusStrip.SuspendLayout();
-			this.toolStripContainer.ContentPanel.SuspendLayout();
-			this.toolStripContainer.TopToolStripPanel.SuspendLayout();
-			this.toolStripContainer.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// toolStripOperations
-			// 
-			this.toolStripOperations.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(80)))), ((int)(((byte)(80)))), ((int)(((byte)(80)))));
-			this.toolStripOperations.ClickThrough = true;
-			this.toolStripOperations.Dock = System.Windows.Forms.DockStyle.None;
-			this.toolStripOperations.ImageScalingSize = new System.Drawing.Size(24, 24);
-			this.toolStripOperations.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(TimedSequenceEditorForm));
+            WeifenLuo.WinFormsUI.Docking.DockPanelSkin dockPanelSkin3 = new WeifenLuo.WinFormsUI.Docking.DockPanelSkin();
+            WeifenLuo.WinFormsUI.Docking.AutoHideStripSkin autoHideStripSkin3 = new WeifenLuo.WinFormsUI.Docking.AutoHideStripSkin();
+            WeifenLuo.WinFormsUI.Docking.DockPanelGradient dockPanelGradient7 = new WeifenLuo.WinFormsUI.Docking.DockPanelGradient();
+            WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient15 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
+            WeifenLuo.WinFormsUI.Docking.DockPaneStripSkin dockPaneStripSkin3 = new WeifenLuo.WinFormsUI.Docking.DockPaneStripSkin();
+            WeifenLuo.WinFormsUI.Docking.DockPaneStripGradient dockPaneStripGradient3 = new WeifenLuo.WinFormsUI.Docking.DockPaneStripGradient();
+            WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient16 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
+            WeifenLuo.WinFormsUI.Docking.DockPanelGradient dockPanelGradient8 = new WeifenLuo.WinFormsUI.Docking.DockPanelGradient();
+            WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient17 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
+            WeifenLuo.WinFormsUI.Docking.DockPaneStripToolWindowGradient dockPaneStripToolWindowGradient3 = new WeifenLuo.WinFormsUI.Docking.DockPaneStripToolWindowGradient();
+            WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient18 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
+            WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient19 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
+            WeifenLuo.WinFormsUI.Docking.DockPanelGradient dockPanelGradient9 = new WeifenLuo.WinFormsUI.Docking.DockPanelGradient();
+            WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient20 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
+            WeifenLuo.WinFormsUI.Docking.TabGradient tabGradient21 = new WeifenLuo.WinFormsUI.Docking.TabGradient();
+            this.toolStripOperations = new Common.Controls.ToolStripEx();
+            this.toolStripButton_Start = new System.Windows.Forms.ToolStripButton();
+            this.toolStripButton_Play = new System.Windows.Forms.ToolStripButton();
+            this.toolStripButton_Stop = new System.Windows.Forms.ToolStripButton();
+            this.toolStripButton_Pause = new System.Windows.Forms.ToolStripButton();
+            this.toolStripButton_End = new System.Windows.Forms.ToolStripButton();
+            this.toolStripButton_Loop = new System.Windows.Forms.ToolStripButton();
+            this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
+            this.undoButton = new Common.Controls.UndoButton();
+            this.redoButton = new Common.Controls.UndoButton();
+            this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripButton_Cut = new System.Windows.Forms.ToolStripButton();
+            this.toolStripButton_Copy = new System.Windows.Forms.ToolStripButton();
+            this.toolStripButton_Paste = new System.Windows.Forms.ToolStripButton();
+            this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripButton_AssociateAudio = new System.Windows.Forms.ToolStripButton();
+            this.toolStripButton_MarkManager = new System.Windows.Forms.ToolStripButton();
+            this.toolStripSeparator13 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripButton_ZoomTimeIn = new System.Windows.Forms.ToolStripButton();
+            this.toolStripButton_ZoomTimeOut = new System.Windows.Forms.ToolStripButton();
+            this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripButton_DrawMode = new System.Windows.Forms.ToolStripButton();
+            this.toolStripButton_SelectionMode = new System.Windows.Forms.ToolStripButton();
+            this.toolStripButton_SnapTo = new System.Windows.Forms.ToolStripButton();
+            this.toolStripDropDownButton_SnapToStrength = new System.Windows.Forms.ToolStripDropDownButton();
+            this.toolStripMenuItem_SnapStrength_1 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_SnapStrength_2 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_SnapStrength_3 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_SnapStrength_4 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripButton_DragBoxFilter = new System.Windows.Forms.ToolStripButton();
+            this.toolStripDropDownButton_DragBoxFilter = new System.Windows.Forms.ToolStripDropDownButton();
+            this.toolStripSplitButton_CloseGaps = new System.Windows.Forms.ToolStripSplitButton();
+            this.toolStripMenuItem_CloseGap100 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_CloseGap200 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_CloseGap300 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_CloseGap400 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripLabel_TimingSpeedLabel = new System.Windows.Forms.ToolStripLabel();
+            this.toolStripLabel_TimingSpeed = new System.Windows.Forms.ToolStripLabel();
+            this.toolStripButton_IncreaseTimingSpeed = new System.Windows.Forms.ToolStripButton();
+            this.toolStripButton_DecreaseTimingSpeed = new System.Windows.Forms.ToolStripButton();
+            this.toolStripSeparator12 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripLabel3 = new System.Windows.Forms.ToolStripLabel();
+            this.cboAudioDevices = new System.Windows.Forms.ToolStripComboBox();
+            this.menuStrip = new Common.Controls.MenuStripEx();
+            this.sequenceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_Save = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_SaveAs = new System.Windows.Forms.ToolStripMenuItem();
+            this.autoSaveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator15 = new System.Windows.Forms.ToolStripSeparator();
+            this.playbackToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.playToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.pauseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.stopToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_Loop = new System.Windows.Forms.ToolStripMenuItem();
+            this.playOptionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.delayOffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.delay5SecondsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.delay10SecondsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.delay20SecondsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.delay30SecondsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.delay60SecondsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator16 = new System.Windows.Forms.ToolStripSeparator();
+            this.exportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripMenuItem_Close = new System.Windows.Forms.ToolStripMenuItem();
+            this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.addEffectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripMenuItem_Cut = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_Copy = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_Paste = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
+            this.undoToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.redoToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+            this.selectAllElementsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_deleteElements = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripMenuItem_SnapTo = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_ResizeIndicator = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_RIColor_Blue = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_RIColor_Yellow = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_RIColor_Green = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_RIColor_White = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_RIColor_Red = new System.Windows.Forms.ToolStripMenuItem();
+            this.cADStyleSelectionBoxToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.viewToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_zoomTimeIn = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_zoomTimeOut = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_zoomRowsIn = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_zoomRowsOut = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+            this.effectWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.markWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.gridWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.effectEditorWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.audioToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_associateAudio = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_removeAudio = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
+            this.beatBarDetectionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_MarkManager = new System.Windows.Forms.ToolStripMenuItem();
+            this.modifySequenceLengthToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.curveEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.colorGradientEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.ColorCollectionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.lipSyncMappingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.defaultMapToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.phonemeMappingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.changeMapToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.lyricConverterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.papagayoImportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.bulkEffectMoveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.helpDocumentationToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.timerPlaying = new System.Windows.Forms.Timer(this.components);
+            this.statusStrip = new System.Windows.Forms.StatusStrip();
+            this.toolStripStatusLabel2 = new System.Windows.Forms.ToolStripStatusLabel();
+            this.toolStripStatusLabel_currentTime = new System.Windows.Forms.ToolStripStatusLabel();
+            this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
+            this.toolStripStatusLabel_sequenceLength = new System.Windows.Forms.ToolStripStatusLabel();
+            this.toolStripStatusLabel3 = new System.Windows.Forms.ToolStripStatusLabel();
+            this.toolStripStatusLabel_delayPlay = new System.Windows.Forms.ToolStripStatusLabel();
+            this.toolStripStatusLabel4 = new System.Windows.Forms.ToolStripStatusLabel();
+            this.toolStripStatusLabel_RenderingElements = new System.Windows.Forms.ToolStripStatusLabel();
+            this.toolStripProgressBar_RenderingElements = new System.Windows.Forms.ToolStripProgressBar();
+            this.openFileDialog = new System.Windows.Forms.OpenFileDialog();
+            this.toolStripContainer = new System.Windows.Forms.ToolStripContainer();
+            this.dockPanel = new WeifenLuo.WinFormsUI.Docking.DockPanel();
+            this.saveFileDialog = new System.Windows.Forms.SaveFileDialog();
+            this.contextMenuStripElementSelection = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.timerPostponePlay = new System.Windows.Forms.Timer(this.components);
+            this.timerDelayCountdown = new System.Windows.Forms.Timer(this.components);
+            this.toolStripMenuItem_expandAllRows = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem_contractAllRows = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripOperations.SuspendLayout();
+            this.menuStrip.SuspendLayout();
+            this.statusStrip.SuspendLayout();
+            this.toolStripContainer.ContentPanel.SuspendLayout();
+            this.toolStripContainer.TopToolStripPanel.SuspendLayout();
+            this.toolStripContainer.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // toolStripOperations
+            // 
+            this.toolStripOperations.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(80)))), ((int)(((byte)(80)))), ((int)(((byte)(80)))));
+            this.toolStripOperations.ClickThrough = true;
+            this.toolStripOperations.Dock = System.Windows.Forms.DockStyle.None;
+            this.toolStripOperations.ImageScalingSize = new System.Drawing.Size(24, 24);
+            this.toolStripOperations.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripButton_Start,
             this.toolStripButton_Play,
             this.toolStripButton_Stop,
@@ -220,412 +222,413 @@ namespace VixenModules.Editor.TimedSequenceEditor
             this.toolStripSeparator12,
             this.toolStripLabel3,
             this.cboAudioDevices});
-			this.toolStripOperations.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;
-			this.toolStripOperations.Location = new System.Drawing.Point(3, 0);
-			this.toolStripOperations.Name = "toolStripOperations";
-			this.toolStripOperations.Size = new System.Drawing.Size(1351, 27);
-			this.toolStripOperations.TabIndex = 1;
-			this.toolStripOperations.Text = "Operations";
-			// 
-			// toolStripButton_Start
-			// 
-			this.toolStripButton_Start.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.toolStripButton_Start.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-			this.toolStripButton_Start.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.toolStripButton_Start.Name = "toolStripButton_Start";
-			this.toolStripButton_Start.Size = new System.Drawing.Size(35, 24);
-			this.toolStripButton_Start.Text = "Start";
-			this.toolStripButton_Start.Click += new System.EventHandler(this.toolStripButton_Start_Click);
-			// 
-			// toolStripButton_Play
-			// 
-			this.toolStripButton_Play.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.toolStripButton_Play.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-			this.toolStripButton_Play.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.toolStripButton_Play.Name = "toolStripButton_Play";
-			this.toolStripButton_Play.Size = new System.Drawing.Size(31, 24);
-			this.toolStripButton_Play.Text = "Play";
-			this.toolStripButton_Play.ToolTipText = "Play F5";
-			this.toolStripButton_Play.Click += new System.EventHandler(this.toolStripButton_Play_Click);
-			// 
-			// toolStripButton_Stop
-			// 
-			this.toolStripButton_Stop.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.toolStripButton_Stop.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-			this.toolStripButton_Stop.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.toolStripButton_Stop.Name = "toolStripButton_Stop";
-			this.toolStripButton_Stop.Size = new System.Drawing.Size(35, 24);
-			this.toolStripButton_Stop.Text = "Stop";
-			this.toolStripButton_Stop.ToolTipText = "Stop F8";
-			this.toolStripButton_Stop.Click += new System.EventHandler(this.toolStripButton_Stop_Click);
-			// 
-			// toolStripButton_Pause
-			// 
-			this.toolStripButton_Pause.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.toolStripButton_Pause.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-			this.toolStripButton_Pause.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.toolStripButton_Pause.Name = "toolStripButton_Pause";
-			this.toolStripButton_Pause.Size = new System.Drawing.Size(41, 24);
-			this.toolStripButton_Pause.Text = "Pause";
-			this.toolStripButton_Pause.ToolTipText = "Pause F6";
-			this.toolStripButton_Pause.Click += new System.EventHandler(this.toolStripButton_Pause_Click);
-			// 
-			// toolStripButton_End
-			// 
-			this.toolStripButton_End.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.toolStripButton_End.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-			this.toolStripButton_End.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.toolStripButton_End.Name = "toolStripButton_End";
-			this.toolStripButton_End.Size = new System.Drawing.Size(31, 24);
-			this.toolStripButton_End.Text = "End";
-			this.toolStripButton_End.Click += new System.EventHandler(this.toolStripButton_End_Click);
-			// 
-			// toolStripButton_Loop
-			// 
-			this.toolStripButton_Loop.CheckOnClick = true;
-			this.toolStripButton_Loop.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.toolStripButton_Loop.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-			this.toolStripButton_Loop.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.toolStripButton_Loop.Name = "toolStripButton_Loop";
-			this.toolStripButton_Loop.Size = new System.Drawing.Size(37, 24);
-			this.toolStripButton_Loop.Text = "Loop";
-			this.toolStripButton_Loop.ToolTipText = "Loop F9";
-			this.toolStripButton_Loop.CheckedChanged += new System.EventHandler(this.toolStripButton_Loop_CheckedChanged);
-			// 
-			// toolStripSeparator4
-			// 
-			this.toolStripSeparator4.Name = "toolStripSeparator4";
-			this.toolStripSeparator4.Size = new System.Drawing.Size(6, 27);
-			// 
-			// undoButton
-			// 
-			this.undoButton.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-			this.undoButton.ButtonType = Common.Controls.UndoButtonType.UndoButton;
-			this.undoButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.undoButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-			this.undoButton.Name = "undoButton";
-			this.undoButton.Size = new System.Drawing.Size(52, 24);
-			this.undoButton.Text = "Undo";
-			this.undoButton.ButtonClick += new System.EventHandler(this.undoButton_ButtonClick);
-			// 
-			// redoButton
-			// 
-			this.redoButton.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-			this.redoButton.ButtonType = Common.Controls.UndoButtonType.UndoButton;
-			this.redoButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.redoButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-			this.redoButton.Name = "redoButton";
-			this.redoButton.Size = new System.Drawing.Size(50, 24);
-			this.redoButton.Text = "Redo";
-			this.redoButton.ButtonClick += new System.EventHandler(this.redoButton_ButtonClick);
-			// 
-			// toolStripSeparator5
-			// 
-			this.toolStripSeparator5.Name = "toolStripSeparator5";
-			this.toolStripSeparator5.Size = new System.Drawing.Size(6, 27);
-			// 
-			// toolStripButton_Cut
-			// 
-			this.toolStripButton_Cut.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.toolStripButton_Cut.Enabled = false;
-			this.toolStripButton_Cut.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-			this.toolStripButton_Cut.Name = "toolStripButton_Cut";
-			this.toolStripButton_Cut.Size = new System.Drawing.Size(29, 24);
-			this.toolStripButton_Cut.Text = "Cut";
-			this.toolStripButton_Cut.Click += new System.EventHandler(this.toolStripMenuItem_Cut_Click);
-			// 
-			// toolStripButton_Copy
-			// 
-			this.toolStripButton_Copy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.toolStripButton_Copy.Enabled = false;
-			this.toolStripButton_Copy.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-			this.toolStripButton_Copy.Name = "toolStripButton_Copy";
-			this.toolStripButton_Copy.Size = new System.Drawing.Size(37, 24);
-			this.toolStripButton_Copy.Text = "Copy";
-			this.toolStripButton_Copy.Click += new System.EventHandler(this.toolStripMenuItem_Copy_Click);
-			// 
-			// toolStripButton_Paste
-			// 
-			this.toolStripButton_Paste.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.toolStripButton_Paste.Enabled = false;
-			this.toolStripButton_Paste.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-			this.toolStripButton_Paste.Name = "toolStripButton_Paste";
-			this.toolStripButton_Paste.Size = new System.Drawing.Size(38, 24);
-			this.toolStripButton_Paste.Text = "Paste";
-			this.toolStripButton_Paste.Click += new System.EventHandler(this.toolStripMenuItem_Paste_Click);
-			// 
-			// toolStripSeparator6
-			// 
-			this.toolStripSeparator6.Name = "toolStripSeparator6";
-			this.toolStripSeparator6.Size = new System.Drawing.Size(6, 27);
-			// 
-			// toolStripButton_AssociateAudio
-			// 
-			this.toolStripButton_AssociateAudio.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.toolStripButton_AssociateAudio.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-			this.toolStripButton_AssociateAudio.Name = "toolStripButton_AssociateAudio";
-			this.toolStripButton_AssociateAudio.Size = new System.Drawing.Size(93, 24);
-			this.toolStripButton_AssociateAudio.Text = "Associate Audio";
-			this.toolStripButton_AssociateAudio.Click += new System.EventHandler(this.toolStripMenuItem_associateAudio_Click);
-			// 
-			// toolStripButton_MarkManager
-			// 
-			this.toolStripButton_MarkManager.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.toolStripButton_MarkManager.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-			this.toolStripButton_MarkManager.Name = "toolStripButton_MarkManager";
-			this.toolStripButton_MarkManager.Size = new System.Drawing.Size(86, 24);
-			this.toolStripButton_MarkManager.Text = "Mark Manager";
-			this.toolStripButton_MarkManager.Click += new System.EventHandler(this.toolStripMenuItem_MarkManager_Click);
-			// 
-			// toolStripSeparator13
-			// 
-			this.toolStripSeparator13.Name = "toolStripSeparator13";
-			this.toolStripSeparator13.Size = new System.Drawing.Size(6, 27);
-			// 
-			// toolStripButton_ZoomTimeIn
-			// 
-			this.toolStripButton_ZoomTimeIn.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.toolStripButton_ZoomTimeIn.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-			this.toolStripButton_ZoomTimeIn.Name = "toolStripButton_ZoomTimeIn";
-			this.toolStripButton_ZoomTimeIn.Size = new System.Drawing.Size(79, 24);
-			this.toolStripButton_ZoomTimeIn.Text = "Zoom Time In";
-			this.toolStripButton_ZoomTimeIn.Click += new System.EventHandler(this.toolStripMenuItem_zoomTimeIn_Click);
-			// 
-			// toolStripButton_ZoomTimeOut
-			// 
-			this.toolStripButton_ZoomTimeOut.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.toolStripButton_ZoomTimeOut.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-			this.toolStripButton_ZoomTimeOut.Name = "toolStripButton_ZoomTimeOut";
-			this.toolStripButton_ZoomTimeOut.Size = new System.Drawing.Size(89, 24);
-			this.toolStripButton_ZoomTimeOut.Text = "Zoom Time Out";
-			this.toolStripButton_ZoomTimeOut.Click += new System.EventHandler(this.toolStripMenuItem_zoomTimeOut_Click);
-			// 
-			// toolStripSeparator9
-			// 
-			this.toolStripSeparator9.Name = "toolStripSeparator9";
-			this.toolStripSeparator9.Size = new System.Drawing.Size(6, 27);
-			// 
-			// toolStripButton_DrawMode
-			// 
-			this.toolStripButton_DrawMode.CheckOnClick = true;
-			this.toolStripButton_DrawMode.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.toolStripButton_DrawMode.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-			this.toolStripButton_DrawMode.Name = "toolStripButton_DrawMode";
-			this.toolStripButton_DrawMode.Size = new System.Drawing.Size(71, 24);
-			this.toolStripButton_DrawMode.Text = "Draw Mode";
-			this.toolStripButton_DrawMode.ToolTipText = "Draw Mode";
-			this.toolStripButton_DrawMode.Click += new System.EventHandler(this.toolStripButton_DrawMode_Click);
-			// 
-			// toolStripButton_SelectionMode
-			// 
-			this.toolStripButton_SelectionMode.Checked = true;
-			this.toolStripButton_SelectionMode.CheckOnClick = true;
-			this.toolStripButton_SelectionMode.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.toolStripButton_SelectionMode.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.toolStripButton_SelectionMode.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-			this.toolStripButton_SelectionMode.Name = "toolStripButton_SelectionMode";
-			this.toolStripButton_SelectionMode.Size = new System.Drawing.Size(91, 24);
-			this.toolStripButton_SelectionMode.Text = "Selection Mode";
-			this.toolStripButton_SelectionMode.Click += new System.EventHandler(this.toolStripButton_SelectionMode_Click);
-			// 
-			// toolStripButton_SnapTo
-			// 
-			this.toolStripButton_SnapTo.CheckOnClick = true;
-			this.toolStripButton_SnapTo.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.toolStripButton_SnapTo.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-			this.toolStripButton_SnapTo.Name = "toolStripButton_SnapTo";
-			this.toolStripButton_SnapTo.Size = new System.Drawing.Size(52, 24);
-			this.toolStripButton_SnapTo.Text = "Snap To";
-			this.toolStripButton_SnapTo.ToolTipText = "Snap To Marks / Effect";
-			this.toolStripButton_SnapTo.CheckedChanged += new System.EventHandler(this.toolStripButton_SnapTo_CheckedChanged);
-			// 
-			// toolStripDropDownButton_SnapToStrength
-			// 
-			this.toolStripDropDownButton_SnapToStrength.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.None;
-			this.toolStripDropDownButton_SnapToStrength.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripOperations.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;
+            this.toolStripOperations.Location = new System.Drawing.Point(3, 0);
+            this.toolStripOperations.Name = "toolStripOperations";
+            this.toolStripOperations.Size = new System.Drawing.Size(1577, 27);
+            this.toolStripOperations.TabIndex = 1;
+            this.toolStripOperations.Text = "Operations";
+            // 
+            // toolStripButton_Start
+            // 
+            this.toolStripButton_Start.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripButton_Start.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.toolStripButton_Start.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStripButton_Start.Name = "toolStripButton_Start";
+            this.toolStripButton_Start.Size = new System.Drawing.Size(35, 24);
+            this.toolStripButton_Start.Text = "Start";
+            this.toolStripButton_Start.Click += new System.EventHandler(this.toolStripButton_Start_Click);
+            // 
+            // toolStripButton_Play
+            // 
+            this.toolStripButton_Play.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripButton_Play.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.toolStripButton_Play.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStripButton_Play.Name = "toolStripButton_Play";
+            this.toolStripButton_Play.Size = new System.Drawing.Size(33, 24);
+            this.toolStripButton_Play.Text = "Play";
+            this.toolStripButton_Play.ToolTipText = "Play F5";
+            this.toolStripButton_Play.Click += new System.EventHandler(this.toolStripButton_Play_Click);
+            // 
+            // toolStripButton_Stop
+            // 
+            this.toolStripButton_Stop.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripButton_Stop.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.toolStripButton_Stop.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStripButton_Stop.Name = "toolStripButton_Stop";
+            this.toolStripButton_Stop.Size = new System.Drawing.Size(35, 24);
+            this.toolStripButton_Stop.Text = "Stop";
+            this.toolStripButton_Stop.ToolTipText = "Stop F8";
+            this.toolStripButton_Stop.Click += new System.EventHandler(this.toolStripButton_Stop_Click);
+            // 
+            // toolStripButton_Pause
+            // 
+            this.toolStripButton_Pause.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripButton_Pause.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.toolStripButton_Pause.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStripButton_Pause.Name = "toolStripButton_Pause";
+            this.toolStripButton_Pause.Size = new System.Drawing.Size(42, 24);
+            this.toolStripButton_Pause.Text = "Pause";
+            this.toolStripButton_Pause.ToolTipText = "Pause F6";
+            this.toolStripButton_Pause.Click += new System.EventHandler(this.toolStripButton_Pause_Click);
+            // 
+            // toolStripButton_End
+            // 
+            this.toolStripButton_End.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripButton_End.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.toolStripButton_End.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStripButton_End.Name = "toolStripButton_End";
+            this.toolStripButton_End.Size = new System.Drawing.Size(31, 24);
+            this.toolStripButton_End.Text = "End";
+            this.toolStripButton_End.Click += new System.EventHandler(this.toolStripButton_End_Click);
+            // 
+            // toolStripButton_Loop
+            // 
+            this.toolStripButton_Loop.CheckOnClick = true;
+            this.toolStripButton_Loop.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripButton_Loop.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.toolStripButton_Loop.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStripButton_Loop.Name = "toolStripButton_Loop";
+            this.toolStripButton_Loop.Size = new System.Drawing.Size(38, 24);
+            this.toolStripButton_Loop.Text = "Loop";
+            this.toolStripButton_Loop.ToolTipText = "Loop F9";
+            this.toolStripButton_Loop.CheckedChanged += new System.EventHandler(this.toolStripButton_Loop_CheckedChanged);
+            // 
+            // toolStripSeparator4
+            // 
+            this.toolStripSeparator4.Name = "toolStripSeparator4";
+            this.toolStripSeparator4.Size = new System.Drawing.Size(6, 27);
+            // 
+            // undoButton
+            // 
+            this.undoButton.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.undoButton.ButtonType = Common.Controls.UndoButtonType.UndoButton;
+            this.undoButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.undoButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.undoButton.Name = "undoButton";
+            this.undoButton.Size = new System.Drawing.Size(52, 24);
+            this.undoButton.Text = "Undo";
+            this.undoButton.ButtonClick += new System.EventHandler(this.undoButton_ButtonClick);
+            // 
+            // redoButton
+            // 
+            this.redoButton.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.redoButton.ButtonType = Common.Controls.UndoButtonType.UndoButton;
+            this.redoButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.redoButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.redoButton.Name = "redoButton";
+            this.redoButton.Size = new System.Drawing.Size(50, 24);
+            this.redoButton.Text = "Redo";
+            this.redoButton.ButtonClick += new System.EventHandler(this.redoButton_ButtonClick);
+            // 
+            // toolStripSeparator5
+            // 
+            this.toolStripSeparator5.Name = "toolStripSeparator5";
+            this.toolStripSeparator5.Size = new System.Drawing.Size(6, 27);
+            // 
+            // toolStripButton_Cut
+            // 
+            this.toolStripButton_Cut.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripButton_Cut.Enabled = false;
+            this.toolStripButton_Cut.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.toolStripButton_Cut.Name = "toolStripButton_Cut";
+            this.toolStripButton_Cut.Size = new System.Drawing.Size(30, 24);
+            this.toolStripButton_Cut.Text = "Cut";
+            this.toolStripButton_Cut.Click += new System.EventHandler(this.toolStripMenuItem_Cut_Click);
+            // 
+            // toolStripButton_Copy
+            // 
+            this.toolStripButton_Copy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripButton_Copy.Enabled = false;
+            this.toolStripButton_Copy.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.toolStripButton_Copy.Name = "toolStripButton_Copy";
+            this.toolStripButton_Copy.Size = new System.Drawing.Size(39, 24);
+            this.toolStripButton_Copy.Text = "Copy";
+            this.toolStripButton_Copy.Click += new System.EventHandler(this.toolStripMenuItem_Copy_Click);
+            // 
+            // toolStripButton_Paste
+            // 
+            this.toolStripButton_Paste.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripButton_Paste.Enabled = false;
+            this.toolStripButton_Paste.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.toolStripButton_Paste.Name = "toolStripButton_Paste";
+            this.toolStripButton_Paste.Size = new System.Drawing.Size(39, 24);
+            this.toolStripButton_Paste.Text = "Paste";
+            this.toolStripButton_Paste.Click += new System.EventHandler(this.toolStripMenuItem_Paste_Click);
+            // 
+            // toolStripSeparator6
+            // 
+            this.toolStripSeparator6.Name = "toolStripSeparator6";
+            this.toolStripSeparator6.Size = new System.Drawing.Size(6, 27);
+            // 
+            // toolStripButton_AssociateAudio
+            // 
+            this.toolStripButton_AssociateAudio.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripButton_AssociateAudio.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.toolStripButton_AssociateAudio.Name = "toolStripButton_AssociateAudio";
+            this.toolStripButton_AssociateAudio.Size = new System.Drawing.Size(96, 24);
+            this.toolStripButton_AssociateAudio.Text = "Associate Audio";
+            this.toolStripButton_AssociateAudio.Click += new System.EventHandler(this.toolStripMenuItem_associateAudio_Click);
+            // 
+            // toolStripButton_MarkManager
+            // 
+            this.toolStripButton_MarkManager.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripButton_MarkManager.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.toolStripButton_MarkManager.Name = "toolStripButton_MarkManager";
+            this.toolStripButton_MarkManager.Size = new System.Drawing.Size(88, 24);
+            this.toolStripButton_MarkManager.Text = "Mark Manager";
+            this.toolStripButton_MarkManager.Click += new System.EventHandler(this.toolStripMenuItem_MarkManager_Click);
+            // 
+            // toolStripSeparator13
+            // 
+            this.toolStripSeparator13.Name = "toolStripSeparator13";
+            this.toolStripSeparator13.Size = new System.Drawing.Size(6, 27);
+            // 
+            // toolStripButton_ZoomTimeIn
+            // 
+            this.toolStripButton_ZoomTimeIn.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripButton_ZoomTimeIn.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.toolStripButton_ZoomTimeIn.Name = "toolStripButton_ZoomTimeIn";
+            this.toolStripButton_ZoomTimeIn.Size = new System.Drawing.Size(86, 24);
+            this.toolStripButton_ZoomTimeIn.Text = "Zoom Time In";
+            this.toolStripButton_ZoomTimeIn.Click += new System.EventHandler(this.toolStripMenuItem_zoomTimeIn_Click);
+            // 
+            // toolStripButton_ZoomTimeOut
+            // 
+            this.toolStripButton_ZoomTimeOut.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripButton_ZoomTimeOut.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.toolStripButton_ZoomTimeOut.Name = "toolStripButton_ZoomTimeOut";
+            this.toolStripButton_ZoomTimeOut.Size = new System.Drawing.Size(96, 24);
+            this.toolStripButton_ZoomTimeOut.Text = "Zoom Time Out";
+            this.toolStripButton_ZoomTimeOut.Click += new System.EventHandler(this.toolStripMenuItem_zoomTimeOut_Click);
+            // 
+            // toolStripSeparator9
+            // 
+            this.toolStripSeparator9.Name = "toolStripSeparator9";
+            this.toolStripSeparator9.Size = new System.Drawing.Size(6, 27);
+            // 
+            // toolStripButton_DrawMode
+            // 
+            this.toolStripButton_DrawMode.CheckOnClick = true;
+            this.toolStripButton_DrawMode.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripButton_DrawMode.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.toolStripButton_DrawMode.Name = "toolStripButton_DrawMode";
+            this.toolStripButton_DrawMode.Size = new System.Drawing.Size(72, 24);
+            this.toolStripButton_DrawMode.Text = "Draw Mode";
+            this.toolStripButton_DrawMode.ToolTipText = "Draw Mode";
+            this.toolStripButton_DrawMode.Click += new System.EventHandler(this.toolStripButton_DrawMode_Click);
+            // 
+            // toolStripButton_SelectionMode
+            // 
+            this.toolStripButton_SelectionMode.Checked = true;
+            this.toolStripButton_SelectionMode.CheckOnClick = true;
+            this.toolStripButton_SelectionMode.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.toolStripButton_SelectionMode.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripButton_SelectionMode.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.toolStripButton_SelectionMode.Name = "toolStripButton_SelectionMode";
+            this.toolStripButton_SelectionMode.Size = new System.Drawing.Size(93, 24);
+            this.toolStripButton_SelectionMode.Text = "Selection Mode";
+            this.toolStripButton_SelectionMode.Click += new System.EventHandler(this.toolStripButton_SelectionMode_Click);
+            // 
+            // toolStripButton_SnapTo
+            // 
+            this.toolStripButton_SnapTo.CheckOnClick = true;
+            this.toolStripButton_SnapTo.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripButton_SnapTo.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.toolStripButton_SnapTo.Name = "toolStripButton_SnapTo";
+            this.toolStripButton_SnapTo.Size = new System.Drawing.Size(53, 24);
+            this.toolStripButton_SnapTo.Text = "Snap To";
+            this.toolStripButton_SnapTo.ToolTipText = "Snap To Marks / Effect";
+            this.toolStripButton_SnapTo.CheckedChanged += new System.EventHandler(this.toolStripButton_SnapTo_CheckedChanged);
+            // 
+            // toolStripDropDownButton_SnapToStrength
+            // 
+            this.toolStripDropDownButton_SnapToStrength.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.None;
+            this.toolStripDropDownButton_SnapToStrength.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItem_SnapStrength_1,
             this.toolStripMenuItem_SnapStrength_2,
             this.toolStripMenuItem_SnapStrength_3,
             this.toolStripMenuItem_SnapStrength_4});
-			this.toolStripDropDownButton_SnapToStrength.Image = ((System.Drawing.Image)(resources.GetObject("toolStripDropDownButton_SnapToStrength.Image")));
-			this.toolStripDropDownButton_SnapToStrength.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.toolStripDropDownButton_SnapToStrength.Name = "toolStripDropDownButton_SnapToStrength";
-			this.toolStripDropDownButton_SnapToStrength.Size = new System.Drawing.Size(13, 24);
-			this.toolStripDropDownButton_SnapToStrength.ToolTipText = "Snap Strength";
-			// 
-			// toolStripMenuItem_SnapStrength_1
-			// 
-			this.toolStripMenuItem_SnapStrength_1.Name = "toolStripMenuItem_SnapStrength_1";
-			this.toolStripMenuItem_SnapStrength_1.Size = new System.Drawing.Size(80, 22);
-			this.toolStripMenuItem_SnapStrength_1.Tag = "2";
-			this.toolStripMenuItem_SnapStrength_1.Text = "1";
-			// 
-			// toolStripMenuItem_SnapStrength_2
-			// 
-			this.toolStripMenuItem_SnapStrength_2.Name = "toolStripMenuItem_SnapStrength_2";
-			this.toolStripMenuItem_SnapStrength_2.ShowShortcutKeys = false;
-			this.toolStripMenuItem_SnapStrength_2.Size = new System.Drawing.Size(80, 22);
-			this.toolStripMenuItem_SnapStrength_2.Tag = "4";
-			this.toolStripMenuItem_SnapStrength_2.Text = "2";
-			// 
-			// toolStripMenuItem_SnapStrength_3
-			// 
-			this.toolStripMenuItem_SnapStrength_3.Name = "toolStripMenuItem_SnapStrength_3";
-			this.toolStripMenuItem_SnapStrength_3.ShowShortcutKeys = false;
-			this.toolStripMenuItem_SnapStrength_3.Size = new System.Drawing.Size(80, 22);
-			this.toolStripMenuItem_SnapStrength_3.Tag = "6";
-			this.toolStripMenuItem_SnapStrength_3.Text = "3";
-			// 
-			// toolStripMenuItem_SnapStrength_4
-			// 
-			this.toolStripMenuItem_SnapStrength_4.Name = "toolStripMenuItem_SnapStrength_4";
-			this.toolStripMenuItem_SnapStrength_4.ShowShortcutKeys = false;
-			this.toolStripMenuItem_SnapStrength_4.Size = new System.Drawing.Size(80, 22);
-			this.toolStripMenuItem_SnapStrength_4.Tag = "8";
-			this.toolStripMenuItem_SnapStrength_4.Text = "4";
-			// 
-			// toolStripButton_DragBoxFilter
-			// 
-			this.toolStripButton_DragBoxFilter.CheckOnClick = true;
-			this.toolStripButton_DragBoxFilter.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.toolStripButton_DragBoxFilter.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-			this.toolStripButton_DragBoxFilter.Name = "toolStripButton_DragBoxFilter";
-			this.toolStripButton_DragBoxFilter.Size = new System.Drawing.Size(87, 24);
-			this.toolStripButton_DragBoxFilter.Text = "Drag Box Filter";
-			this.toolStripButton_DragBoxFilter.CheckedChanged += new System.EventHandler(this.toolStripButton_DragBoxFilter_CheckedChanged);
-			// 
-			// toolStripDropDownButton_DragBoxFilter
-			// 
-			this.toolStripDropDownButton_DragBoxFilter.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.None;
-			this.toolStripDropDownButton_DragBoxFilter.Image = ((System.Drawing.Image)(resources.GetObject("toolStripDropDownButton_DragBoxFilter.Image")));
-			this.toolStripDropDownButton_DragBoxFilter.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.toolStripDropDownButton_DragBoxFilter.Name = "toolStripDropDownButton_DragBoxFilter";
-			this.toolStripDropDownButton_DragBoxFilter.Size = new System.Drawing.Size(13, 24);
-			this.toolStripDropDownButton_DragBoxFilter.ToolTipText = "Drag Box Filter";
-			// 
-			// toolStripSplitButton_CloseGaps
-			// 
-			this.toolStripSplitButton_CloseGaps.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.toolStripSplitButton_CloseGaps.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripDropDownButton_SnapToStrength.Image = ((System.Drawing.Image)(resources.GetObject("toolStripDropDownButton_SnapToStrength.Image")));
+            this.toolStripDropDownButton_SnapToStrength.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStripDropDownButton_SnapToStrength.Name = "toolStripDropDownButton_SnapToStrength";
+            this.toolStripDropDownButton_SnapToStrength.Size = new System.Drawing.Size(13, 24);
+            this.toolStripDropDownButton_SnapToStrength.ToolTipText = "Snap Strength";
+            // 
+            // toolStripMenuItem_SnapStrength_1
+            // 
+            this.toolStripMenuItem_SnapStrength_1.Name = "toolStripMenuItem_SnapStrength_1";
+            this.toolStripMenuItem_SnapStrength_1.Size = new System.Drawing.Size(80, 22);
+            this.toolStripMenuItem_SnapStrength_1.Tag = "2";
+            this.toolStripMenuItem_SnapStrength_1.Text = "1";
+            // 
+            // toolStripMenuItem_SnapStrength_2
+            // 
+            this.toolStripMenuItem_SnapStrength_2.Name = "toolStripMenuItem_SnapStrength_2";
+            this.toolStripMenuItem_SnapStrength_2.ShowShortcutKeys = false;
+            this.toolStripMenuItem_SnapStrength_2.Size = new System.Drawing.Size(80, 22);
+            this.toolStripMenuItem_SnapStrength_2.Tag = "4";
+            this.toolStripMenuItem_SnapStrength_2.Text = "2";
+            // 
+            // toolStripMenuItem_SnapStrength_3
+            // 
+            this.toolStripMenuItem_SnapStrength_3.Name = "toolStripMenuItem_SnapStrength_3";
+            this.toolStripMenuItem_SnapStrength_3.ShowShortcutKeys = false;
+            this.toolStripMenuItem_SnapStrength_3.Size = new System.Drawing.Size(80, 22);
+            this.toolStripMenuItem_SnapStrength_3.Tag = "6";
+            this.toolStripMenuItem_SnapStrength_3.Text = "3";
+            // 
+            // toolStripMenuItem_SnapStrength_4
+            // 
+            this.toolStripMenuItem_SnapStrength_4.Name = "toolStripMenuItem_SnapStrength_4";
+            this.toolStripMenuItem_SnapStrength_4.ShowShortcutKeys = false;
+            this.toolStripMenuItem_SnapStrength_4.Size = new System.Drawing.Size(80, 22);
+            this.toolStripMenuItem_SnapStrength_4.Tag = "8";
+            this.toolStripMenuItem_SnapStrength_4.Text = "4";
+            // 
+            // toolStripButton_DragBoxFilter
+            // 
+            this.toolStripButton_DragBoxFilter.CheckOnClick = true;
+            this.toolStripButton_DragBoxFilter.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripButton_DragBoxFilter.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.toolStripButton_DragBoxFilter.Name = "toolStripButton_DragBoxFilter";
+            this.toolStripButton_DragBoxFilter.Size = new System.Drawing.Size(87, 24);
+            this.toolStripButton_DragBoxFilter.Text = "Drag Box Filter";
+            this.toolStripButton_DragBoxFilter.CheckedChanged += new System.EventHandler(this.toolStripButton_DragBoxFilter_CheckedChanged);
+            // 
+            // toolStripDropDownButton_DragBoxFilter
+            // 
+            this.toolStripDropDownButton_DragBoxFilter.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.None;
+            this.toolStripDropDownButton_DragBoxFilter.Image = ((System.Drawing.Image)(resources.GetObject("toolStripDropDownButton_DragBoxFilter.Image")));
+            this.toolStripDropDownButton_DragBoxFilter.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStripDropDownButton_DragBoxFilter.Name = "toolStripDropDownButton_DragBoxFilter";
+            this.toolStripDropDownButton_DragBoxFilter.Size = new System.Drawing.Size(13, 24);
+            this.toolStripDropDownButton_DragBoxFilter.ToolTipText = "Drag Box Filter";
+            // 
+            // toolStripSplitButton_CloseGaps
+            // 
+            this.toolStripSplitButton_CloseGaps.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripSplitButton_CloseGaps.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItem_CloseGap100,
             this.toolStripMenuItem_CloseGap200,
             this.toolStripMenuItem_CloseGap300,
             this.toolStripMenuItem_CloseGap400});
-			this.toolStripSplitButton_CloseGaps.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-			this.toolStripSplitButton_CloseGaps.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.toolStripSplitButton_CloseGaps.Name = "toolStripSplitButton_CloseGaps";
-			this.toolStripSplitButton_CloseGaps.Size = new System.Drawing.Size(80, 24);
-			this.toolStripSplitButton_CloseGaps.Text = "Close Gaps";
-			this.toolStripSplitButton_CloseGaps.ButtonClick += new System.EventHandler(this.toolStripSplitButton_CloseGaps_ButtonClick);
-			// 
-			// toolStripMenuItem_CloseGap100
-			// 
-			this.toolStripMenuItem_CloseGap100.Name = "toolStripMenuItem_CloseGap100";
-			this.toolStripMenuItem_CloseGap100.Size = new System.Drawing.Size(95, 22);
-			this.toolStripMenuItem_CloseGap100.Tag = ".100";
-			this.toolStripMenuItem_CloseGap100.Text = ".100";
-			// 
-			// toolStripMenuItem_CloseGap200
-			// 
-			this.toolStripMenuItem_CloseGap200.Name = "toolStripMenuItem_CloseGap200";
-			this.toolStripMenuItem_CloseGap200.Size = new System.Drawing.Size(95, 22);
-			this.toolStripMenuItem_CloseGap200.Tag = ".200";
-			this.toolStripMenuItem_CloseGap200.Text = ".200";
-			// 
-			// toolStripMenuItem_CloseGap300
-			// 
-			this.toolStripMenuItem_CloseGap300.Name = "toolStripMenuItem_CloseGap300";
-			this.toolStripMenuItem_CloseGap300.Size = new System.Drawing.Size(95, 22);
-			this.toolStripMenuItem_CloseGap300.Tag = ".300";
-			this.toolStripMenuItem_CloseGap300.Text = ".300";
-			// 
-			// toolStripMenuItem_CloseGap400
-			// 
-			this.toolStripMenuItem_CloseGap400.Name = "toolStripMenuItem_CloseGap400";
-			this.toolStripMenuItem_CloseGap400.Size = new System.Drawing.Size(95, 22);
-			this.toolStripMenuItem_CloseGap400.Tag = ".400";
-			this.toolStripMenuItem_CloseGap400.Text = ".400";
-			// 
-			// toolStripSeparator11
-			// 
-			this.toolStripSeparator11.Name = "toolStripSeparator11";
-			this.toolStripSeparator11.Size = new System.Drawing.Size(6, 27);
-			// 
-			// toolStripLabel_TimingSpeedLabel
-			// 
-			this.toolStripLabel_TimingSpeedLabel.BackColor = System.Drawing.Color.Gray;
-			this.toolStripLabel_TimingSpeedLabel.Name = "toolStripLabel_TimingSpeedLabel";
-			this.toolStripLabel_TimingSpeedLabel.Size = new System.Drawing.Size(78, 24);
-			this.toolStripLabel_TimingSpeedLabel.Text = "Timing speed:";
-			// 
-			// toolStripLabel_TimingSpeed
-			// 
-			this.toolStripLabel_TimingSpeed.Name = "toolStripLabel_TimingSpeed";
-			this.toolStripLabel_TimingSpeed.Size = new System.Drawing.Size(34, 24);
-			this.toolStripLabel_TimingSpeed.Text = "100%";
-			// 
-			// toolStripButton_IncreaseTimingSpeed
-			// 
-			this.toolStripButton_IncreaseTimingSpeed.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.toolStripButton_IncreaseTimingSpeed.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-			this.toolStripButton_IncreaseTimingSpeed.Name = "toolStripButton_IncreaseTimingSpeed";
-			this.toolStripButton_IncreaseTimingSpeed.Size = new System.Drawing.Size(87, 17);
-			this.toolStripButton_IncreaseTimingSpeed.Text = "Increase speed";
-			this.toolStripButton_IncreaseTimingSpeed.Click += new System.EventHandler(this.toolStripButton_IncreaseTimingSpeed_Click);
-			// 
-			// toolStripButton_DecreaseTimingSpeed
-			// 
-			this.toolStripButton_DecreaseTimingSpeed.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.toolStripButton_DecreaseTimingSpeed.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-			this.toolStripButton_DecreaseTimingSpeed.Name = "toolStripButton_DecreaseTimingSpeed";
-			this.toolStripButton_DecreaseTimingSpeed.Size = new System.Drawing.Size(91, 17);
-			this.toolStripButton_DecreaseTimingSpeed.Text = "Decrease speed";
-			this.toolStripButton_DecreaseTimingSpeed.Click += new System.EventHandler(this.toolStripButton_DecreaseTimingSpeed_Click);
-			// 
-			// toolStripSeparator12
-			// 
-			this.toolStripSeparator12.Name = "toolStripSeparator12";
-			this.toolStripSeparator12.Size = new System.Drawing.Size(6, 25);
-			// 
-			// toolStripLabel3
-			// 
-			this.toolStripLabel3.Name = "toolStripLabel3";
-			this.toolStripLabel3.Size = new System.Drawing.Size(74, 13);
-			this.toolStripLabel3.Text = "Audio Device";
-			// 
-			// cboAudioDevices
-			// 
-			this.cboAudioDevices.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(80)))), ((int)(((byte)(80)))), ((int)(((byte)(80)))));
-			this.cboAudioDevices.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.cboAudioDevices.DropDownWidth = 220;
-			this.cboAudioDevices.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.cboAudioDevices.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.cboAudioDevices.Name = "cboAudioDevices";
-			this.cboAudioDevices.Size = new System.Drawing.Size(250, 23);
-			this.cboAudioDevices.SelectedIndexChanged += new System.EventHandler(this.cboAudioDevices_SelectedIndexChanged);
-			this.cboAudioDevices.TextChanged += new System.EventHandler(this.cboAudioDevices_TextChanged);
-			// 
-			// menuStrip
-			// 
-			this.menuStrip.BackColor = System.Drawing.Color.Transparent;
-			this.menuStrip.ClickThrough = true;
-			this.menuStrip.ImageScalingSize = new System.Drawing.Size(24, 24);
-			this.menuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripSplitButton_CloseGaps.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.toolStripSplitButton_CloseGaps.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStripSplitButton_CloseGaps.Name = "toolStripSplitButton_CloseGaps";
+            this.toolStripSplitButton_CloseGaps.Size = new System.Drawing.Size(81, 24);
+            this.toolStripSplitButton_CloseGaps.Text = "Close Gaps";
+            this.toolStripSplitButton_CloseGaps.ButtonClick += new System.EventHandler(this.toolStripSplitButton_CloseGaps_ButtonClick);
+            // 
+            // toolStripMenuItem_CloseGap100
+            // 
+            this.toolStripMenuItem_CloseGap100.Name = "toolStripMenuItem_CloseGap100";
+            this.toolStripMenuItem_CloseGap100.Size = new System.Drawing.Size(95, 22);
+            this.toolStripMenuItem_CloseGap100.Tag = ".100";
+            this.toolStripMenuItem_CloseGap100.Text = ".100";
+            // 
+            // toolStripMenuItem_CloseGap200
+            // 
+            this.toolStripMenuItem_CloseGap200.Name = "toolStripMenuItem_CloseGap200";
+            this.toolStripMenuItem_CloseGap200.Size = new System.Drawing.Size(95, 22);
+            this.toolStripMenuItem_CloseGap200.Tag = ".200";
+            this.toolStripMenuItem_CloseGap200.Text = ".200";
+            // 
+            // toolStripMenuItem_CloseGap300
+            // 
+            this.toolStripMenuItem_CloseGap300.Name = "toolStripMenuItem_CloseGap300";
+            this.toolStripMenuItem_CloseGap300.Size = new System.Drawing.Size(95, 22);
+            this.toolStripMenuItem_CloseGap300.Tag = ".300";
+            this.toolStripMenuItem_CloseGap300.Text = ".300";
+            // 
+            // toolStripMenuItem_CloseGap400
+            // 
+            this.toolStripMenuItem_CloseGap400.Name = "toolStripMenuItem_CloseGap400";
+            this.toolStripMenuItem_CloseGap400.Size = new System.Drawing.Size(95, 22);
+            this.toolStripMenuItem_CloseGap400.Tag = ".400";
+            this.toolStripMenuItem_CloseGap400.Text = ".400";
+            // 
+            // toolStripSeparator11
+            // 
+            this.toolStripSeparator11.Name = "toolStripSeparator11";
+            this.toolStripSeparator11.Size = new System.Drawing.Size(6, 27);
+            // 
+            // toolStripLabel_TimingSpeedLabel
+            // 
+            this.toolStripLabel_TimingSpeedLabel.BackColor = System.Drawing.Color.Gray;
+            this.toolStripLabel_TimingSpeedLabel.Name = "toolStripLabel_TimingSpeedLabel";
+            this.toolStripLabel_TimingSpeedLabel.Size = new System.Drawing.Size(82, 24);
+            this.toolStripLabel_TimingSpeedLabel.Text = "Timing speed:";
+            // 
+            // toolStripLabel_TimingSpeed
+            // 
+            this.toolStripLabel_TimingSpeed.Name = "toolStripLabel_TimingSpeed";
+            this.toolStripLabel_TimingSpeed.Size = new System.Drawing.Size(35, 24);
+            this.toolStripLabel_TimingSpeed.Text = "100%";
+            // 
+            // toolStripButton_IncreaseTimingSpeed
+            // 
+            this.toolStripButton_IncreaseTimingSpeed.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripButton_IncreaseTimingSpeed.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.toolStripButton_IncreaseTimingSpeed.Name = "toolStripButton_IncreaseTimingSpeed";
+            this.toolStripButton_IncreaseTimingSpeed.Size = new System.Drawing.Size(88, 24);
+            this.toolStripButton_IncreaseTimingSpeed.Text = "Increase speed";
+            this.toolStripButton_IncreaseTimingSpeed.Click += new System.EventHandler(this.toolStripButton_IncreaseTimingSpeed_Click);
+            // 
+            // toolStripButton_DecreaseTimingSpeed
+            // 
+            this.toolStripButton_DecreaseTimingSpeed.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripButton_DecreaseTimingSpeed.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.toolStripButton_DecreaseTimingSpeed.Name = "toolStripButton_DecreaseTimingSpeed";
+            this.toolStripButton_DecreaseTimingSpeed.Size = new System.Drawing.Size(92, 24);
+            this.toolStripButton_DecreaseTimingSpeed.Text = "Decrease speed";
+            this.toolStripButton_DecreaseTimingSpeed.Click += new System.EventHandler(this.toolStripButton_DecreaseTimingSpeed_Click);
+            // 
+            // toolStripSeparator12
+            // 
+            this.toolStripSeparator12.Name = "toolStripSeparator12";
+            this.toolStripSeparator12.Size = new System.Drawing.Size(6, 27);
+            // 
+            // toolStripLabel3
+            // 
+            this.toolStripLabel3.Name = "toolStripLabel3";
+            this.toolStripLabel3.Size = new System.Drawing.Size(77, 15);
+            this.toolStripLabel3.Text = "Audio Device";
+            // 
+            // cboAudioDevices
+            // 
+            this.cboAudioDevices.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(80)))), ((int)(((byte)(80)))), ((int)(((byte)(80)))));
+            this.cboAudioDevices.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cboAudioDevices.DropDownWidth = 220;
+            this.cboAudioDevices.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cboAudioDevices.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.cboAudioDevices.Name = "cboAudioDevices";
+            this.cboAudioDevices.Size = new System.Drawing.Size(250, 23);
+            this.cboAudioDevices.SelectedIndexChanged += new System.EventHandler(this.cboAudioDevices_SelectedIndexChanged);
+            this.cboAudioDevices.TextChanged += new System.EventHandler(this.cboAudioDevices_TextChanged);
+            // 
+            // menuStrip
+            // 
+            this.menuStrip.BackColor = System.Drawing.Color.Transparent;
+            this.menuStrip.ClickThrough = true;
+            this.menuStrip.ImageScalingSize = new System.Drawing.Size(24, 24);
+            this.menuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.sequenceToolStripMenuItem,
             this.editToolStripMenuItem,
             this.viewToolStripMenuItem,
             this.toolsToolStripMenuItem,
             this.helpDocumentationToolStripMenuItem});
-			this.menuStrip.Location = new System.Drawing.Point(0, 0);
-			this.menuStrip.Name = "menuStrip";
-			this.menuStrip.Size = new System.Drawing.Size(1354, 24);
-			this.menuStrip.TabIndex = 2;
-			this.menuStrip.Text = "Menu";
-			this.menuStrip.MenuActivate += new System.EventHandler(this.menuStrip_MenuActivate);
-			// 
-			// sequenceToolStripMenuItem
-			// 
-			this.sequenceToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.menuStrip.Location = new System.Drawing.Point(0, 0);
+            this.menuStrip.Name = "menuStrip";
+            this.menuStrip.Padding = new System.Windows.Forms.Padding(7, 2, 0, 2);
+            this.menuStrip.Size = new System.Drawing.Size(1580, 24);
+            this.menuStrip.TabIndex = 2;
+            this.menuStrip.Text = "Menu";
+            this.menuStrip.MenuActivate += new System.EventHandler(this.menuStrip_MenuActivate);
+            // 
+            // sequenceToolStripMenuItem
+            // 
+            this.sequenceToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItem_Save,
             this.toolStripMenuItem_SaveAs,
             this.autoSaveToolStripMenuItem,
@@ -635,180 +638,180 @@ namespace VixenModules.Editor.TimedSequenceEditor
             this.exportToolStripMenuItem,
             this.toolStripSeparator1,
             this.toolStripMenuItem_Close});
-			this.sequenceToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.sequenceToolStripMenuItem.Name = "sequenceToolStripMenuItem";
-			this.sequenceToolStripMenuItem.Size = new System.Drawing.Size(70, 20);
-			this.sequenceToolStripMenuItem.Text = "Sequence";
-			// 
-			// toolStripMenuItem_Save
-			// 
-			this.toolStripMenuItem_Save.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripMenuItem_Save.Name = "toolStripMenuItem_Save";
-			this.toolStripMenuItem_Save.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-			this.toolStripMenuItem_Save.Size = new System.Drawing.Size(186, 22);
-			this.toolStripMenuItem_Save.Text = "Save";
-			this.toolStripMenuItem_Save.Click += new System.EventHandler(this.toolStripMenuItem_Save_Click);
-			// 
-			// toolStripMenuItem_SaveAs
-			// 
-			this.toolStripMenuItem_SaveAs.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripMenuItem_SaveAs.Name = "toolStripMenuItem_SaveAs";
-			this.toolStripMenuItem_SaveAs.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Alt) 
+            this.sequenceToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.sequenceToolStripMenuItem.Name = "sequenceToolStripMenuItem";
+            this.sequenceToolStripMenuItem.Size = new System.Drawing.Size(70, 20);
+            this.sequenceToolStripMenuItem.Text = "Sequence";
+            // 
+            // toolStripMenuItem_Save
+            // 
+            this.toolStripMenuItem_Save.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripMenuItem_Save.Name = "toolStripMenuItem_Save";
+            this.toolStripMenuItem_Save.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
+            this.toolStripMenuItem_Save.Size = new System.Drawing.Size(186, 22);
+            this.toolStripMenuItem_Save.Text = "Save";
+            this.toolStripMenuItem_Save.Click += new System.EventHandler(this.toolStripMenuItem_Save_Click);
+            // 
+            // toolStripMenuItem_SaveAs
+            // 
+            this.toolStripMenuItem_SaveAs.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripMenuItem_SaveAs.Name = "toolStripMenuItem_SaveAs";
+            this.toolStripMenuItem_SaveAs.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Alt) 
             | System.Windows.Forms.Keys.S)));
-			this.toolStripMenuItem_SaveAs.Size = new System.Drawing.Size(186, 22);
-			this.toolStripMenuItem_SaveAs.Text = "Save As...";
-			this.toolStripMenuItem_SaveAs.Click += new System.EventHandler(this.toolStripMenuItem_SaveAs_Click);
-			// 
-			// autoSaveToolStripMenuItem
-			// 
-			this.autoSaveToolStripMenuItem.Checked = true;
-			this.autoSaveToolStripMenuItem.CheckOnClick = true;
-			this.autoSaveToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.autoSaveToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.autoSaveToolStripMenuItem.Name = "autoSaveToolStripMenuItem";
-			this.autoSaveToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
-			this.autoSaveToolStripMenuItem.Text = "Auto Save";
-			this.autoSaveToolStripMenuItem.CheckedChanged += new System.EventHandler(this.toolStripMenuItem_AutoSave_Click);
-			// 
-			// toolStripSeparator15
-			// 
-			this.toolStripSeparator15.Name = "toolStripSeparator15";
-			this.toolStripSeparator15.Size = new System.Drawing.Size(183, 6);
-			// 
-			// playbackToolStripMenuItem
-			// 
-			this.playbackToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItem_SaveAs.Size = new System.Drawing.Size(186, 22);
+            this.toolStripMenuItem_SaveAs.Text = "Save As...";
+            this.toolStripMenuItem_SaveAs.Click += new System.EventHandler(this.toolStripMenuItem_SaveAs_Click);
+            // 
+            // autoSaveToolStripMenuItem
+            // 
+            this.autoSaveToolStripMenuItem.Checked = true;
+            this.autoSaveToolStripMenuItem.CheckOnClick = true;
+            this.autoSaveToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.autoSaveToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.autoSaveToolStripMenuItem.Name = "autoSaveToolStripMenuItem";
+            this.autoSaveToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
+            this.autoSaveToolStripMenuItem.Text = "Auto Save";
+            this.autoSaveToolStripMenuItem.CheckedChanged += new System.EventHandler(this.toolStripMenuItem_AutoSave_Click);
+            // 
+            // toolStripSeparator15
+            // 
+            this.toolStripSeparator15.Name = "toolStripSeparator15";
+            this.toolStripSeparator15.Size = new System.Drawing.Size(183, 6);
+            // 
+            // playbackToolStripMenuItem
+            // 
+            this.playbackToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.playToolStripMenuItem,
             this.pauseToolStripMenuItem,
             this.stopToolStripMenuItem,
             this.toolStripMenuItem_Loop,
             this.playOptionsToolStripMenuItem});
-			this.playbackToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.playbackToolStripMenuItem.Name = "playbackToolStripMenuItem";
-			this.playbackToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
-			this.playbackToolStripMenuItem.Text = "Playback";
-			// 
-			// playToolStripMenuItem
-			// 
-			this.playToolStripMenuItem.Name = "playToolStripMenuItem";
-			this.playToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F5;
-			this.playToolStripMenuItem.Size = new System.Drawing.Size(141, 22);
-			this.playToolStripMenuItem.Text = "Play";
-			this.playToolStripMenuItem.Click += new System.EventHandler(this.playToolStripMenuItem_Click);
-			// 
-			// pauseToolStripMenuItem
-			// 
-			this.pauseToolStripMenuItem.Name = "pauseToolStripMenuItem";
-			this.pauseToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F6;
-			this.pauseToolStripMenuItem.Size = new System.Drawing.Size(141, 22);
-			this.pauseToolStripMenuItem.Text = "Pause";
-			this.pauseToolStripMenuItem.Click += new System.EventHandler(this.pauseToolStripMenuItem_Click);
-			// 
-			// stopToolStripMenuItem
-			// 
-			this.stopToolStripMenuItem.Name = "stopToolStripMenuItem";
-			this.stopToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F8;
-			this.stopToolStripMenuItem.Size = new System.Drawing.Size(141, 22);
-			this.stopToolStripMenuItem.Text = "Stop";
-			this.stopToolStripMenuItem.Click += new System.EventHandler(this.stopToolStripMenuItem_Click);
-			// 
-			// toolStripMenuItem_Loop
-			// 
-			this.toolStripMenuItem_Loop.CheckOnClick = true;
-			this.toolStripMenuItem_Loop.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.toolStripMenuItem_Loop.Name = "toolStripMenuItem_Loop";
-			this.toolStripMenuItem_Loop.ShortcutKeys = System.Windows.Forms.Keys.F9;
-			this.toolStripMenuItem_Loop.Size = new System.Drawing.Size(141, 22);
-			this.toolStripMenuItem_Loop.Text = "Loop";
-			this.toolStripMenuItem_Loop.CheckedChanged += new System.EventHandler(this.toolStripMenuItem_Loop_CheckedChanged);
-			// 
-			// playOptionsToolStripMenuItem
-			// 
-			this.playOptionsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.playbackToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.playbackToolStripMenuItem.Name = "playbackToolStripMenuItem";
+            this.playbackToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
+            this.playbackToolStripMenuItem.Text = "Playback";
+            // 
+            // playToolStripMenuItem
+            // 
+            this.playToolStripMenuItem.Name = "playToolStripMenuItem";
+            this.playToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F5;
+            this.playToolStripMenuItem.Size = new System.Drawing.Size(141, 22);
+            this.playToolStripMenuItem.Text = "Play";
+            this.playToolStripMenuItem.Click += new System.EventHandler(this.playToolStripMenuItem_Click);
+            // 
+            // pauseToolStripMenuItem
+            // 
+            this.pauseToolStripMenuItem.Name = "pauseToolStripMenuItem";
+            this.pauseToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F6;
+            this.pauseToolStripMenuItem.Size = new System.Drawing.Size(141, 22);
+            this.pauseToolStripMenuItem.Text = "Pause";
+            this.pauseToolStripMenuItem.Click += new System.EventHandler(this.pauseToolStripMenuItem_Click);
+            // 
+            // stopToolStripMenuItem
+            // 
+            this.stopToolStripMenuItem.Name = "stopToolStripMenuItem";
+            this.stopToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F8;
+            this.stopToolStripMenuItem.Size = new System.Drawing.Size(141, 22);
+            this.stopToolStripMenuItem.Text = "Stop";
+            this.stopToolStripMenuItem.Click += new System.EventHandler(this.stopToolStripMenuItem_Click);
+            // 
+            // toolStripMenuItem_Loop
+            // 
+            this.toolStripMenuItem_Loop.CheckOnClick = true;
+            this.toolStripMenuItem_Loop.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripMenuItem_Loop.Name = "toolStripMenuItem_Loop";
+            this.toolStripMenuItem_Loop.ShortcutKeys = System.Windows.Forms.Keys.F9;
+            this.toolStripMenuItem_Loop.Size = new System.Drawing.Size(141, 22);
+            this.toolStripMenuItem_Loop.Text = "Loop";
+            this.toolStripMenuItem_Loop.CheckedChanged += new System.EventHandler(this.toolStripMenuItem_Loop_CheckedChanged);
+            // 
+            // playOptionsToolStripMenuItem
+            // 
+            this.playOptionsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.delayOffToolStripMenuItem,
             this.delay5SecondsToolStripMenuItem,
             this.delay10SecondsToolStripMenuItem,
             this.delay20SecondsToolStripMenuItem,
             this.delay30SecondsToolStripMenuItem,
             this.delay60SecondsToolStripMenuItem});
-			this.playOptionsToolStripMenuItem.Name = "playOptionsToolStripMenuItem";
-			this.playOptionsToolStripMenuItem.Size = new System.Drawing.Size(141, 22);
-			this.playOptionsToolStripMenuItem.Text = "Play Options";
-			// 
-			// delayOffToolStripMenuItem
-			// 
-			this.delayOffToolStripMenuItem.Checked = true;
-			this.delayOffToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.delayOffToolStripMenuItem.Name = "delayOffToolStripMenuItem";
-			this.delayOffToolStripMenuItem.Size = new System.Drawing.Size(165, 22);
-			this.delayOffToolStripMenuItem.Text = "Delay Off";
-			this.delayOffToolStripMenuItem.Click += new System.EventHandler(this.delayOffToolStripMenuItem_Click);
-			// 
-			// delay5SecondsToolStripMenuItem
-			// 
-			this.delay5SecondsToolStripMenuItem.Name = "delay5SecondsToolStripMenuItem";
-			this.delay5SecondsToolStripMenuItem.Size = new System.Drawing.Size(165, 22);
-			this.delay5SecondsToolStripMenuItem.Text = "Delay 5 Seconds";
-			this.delay5SecondsToolStripMenuItem.Click += new System.EventHandler(this.delay5SecondsToolStripMenuItem_Click);
-			// 
-			// delay10SecondsToolStripMenuItem
-			// 
-			this.delay10SecondsToolStripMenuItem.Name = "delay10SecondsToolStripMenuItem";
-			this.delay10SecondsToolStripMenuItem.Size = new System.Drawing.Size(165, 22);
-			this.delay10SecondsToolStripMenuItem.Text = "Delay 10 Seconds";
-			this.delay10SecondsToolStripMenuItem.Click += new System.EventHandler(this.delay10SecondsToolStripMenuItem_Click);
-			// 
-			// delay20SecondsToolStripMenuItem
-			// 
-			this.delay20SecondsToolStripMenuItem.Name = "delay20SecondsToolStripMenuItem";
-			this.delay20SecondsToolStripMenuItem.Size = new System.Drawing.Size(165, 22);
-			this.delay20SecondsToolStripMenuItem.Text = "Delay 20 Seconds";
-			this.delay20SecondsToolStripMenuItem.Click += new System.EventHandler(this.delay20SecondsToolStripMenuItem_Click);
-			// 
-			// delay30SecondsToolStripMenuItem
-			// 
-			this.delay30SecondsToolStripMenuItem.Name = "delay30SecondsToolStripMenuItem";
-			this.delay30SecondsToolStripMenuItem.Size = new System.Drawing.Size(165, 22);
-			this.delay30SecondsToolStripMenuItem.Text = "Delay 30 Seconds";
-			this.delay30SecondsToolStripMenuItem.Click += new System.EventHandler(this.delay30SecondsToolStripMenuItem_Click);
-			// 
-			// delay60SecondsToolStripMenuItem
-			// 
-			this.delay60SecondsToolStripMenuItem.Name = "delay60SecondsToolStripMenuItem";
-			this.delay60SecondsToolStripMenuItem.Size = new System.Drawing.Size(165, 22);
-			this.delay60SecondsToolStripMenuItem.Text = "Delay 60 Seconds";
-			this.delay60SecondsToolStripMenuItem.Click += new System.EventHandler(this.delay60SecondsToolStripMenuItem_Click);
-			// 
-			// toolStripSeparator16
-			// 
-			this.toolStripSeparator16.Name = "toolStripSeparator16";
-			this.toolStripSeparator16.Size = new System.Drawing.Size(183, 6);
-			// 
-			// exportToolStripMenuItem
-			// 
-			this.exportToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.exportToolStripMenuItem.Name = "exportToolStripMenuItem";
-			this.exportToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
-			this.exportToolStripMenuItem.Text = "Export";
-			this.exportToolStripMenuItem.Click += new System.EventHandler(this.exportToolStripMenuItem_Click);
-			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(183, 6);
-			// 
-			// toolStripMenuItem_Close
-			// 
-			this.toolStripMenuItem_Close.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripMenuItem_Close.Name = "toolStripMenuItem_Close";
-			this.toolStripMenuItem_Close.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Q)));
-			this.toolStripMenuItem_Close.Size = new System.Drawing.Size(186, 22);
-			this.toolStripMenuItem_Close.Text = "Close";
-			this.toolStripMenuItem_Close.Click += new System.EventHandler(this.toolStripMenuItem_Close_Click);
-			// 
-			// editToolStripMenuItem
-			// 
-			this.editToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.playOptionsToolStripMenuItem.Name = "playOptionsToolStripMenuItem";
+            this.playOptionsToolStripMenuItem.Size = new System.Drawing.Size(141, 22);
+            this.playOptionsToolStripMenuItem.Text = "Play Options";
+            // 
+            // delayOffToolStripMenuItem
+            // 
+            this.delayOffToolStripMenuItem.Checked = true;
+            this.delayOffToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.delayOffToolStripMenuItem.Name = "delayOffToolStripMenuItem";
+            this.delayOffToolStripMenuItem.Size = new System.Drawing.Size(165, 22);
+            this.delayOffToolStripMenuItem.Text = "Delay Off";
+            this.delayOffToolStripMenuItem.Click += new System.EventHandler(this.delayOffToolStripMenuItem_Click);
+            // 
+            // delay5SecondsToolStripMenuItem
+            // 
+            this.delay5SecondsToolStripMenuItem.Name = "delay5SecondsToolStripMenuItem";
+            this.delay5SecondsToolStripMenuItem.Size = new System.Drawing.Size(165, 22);
+            this.delay5SecondsToolStripMenuItem.Text = "Delay 5 Seconds";
+            this.delay5SecondsToolStripMenuItem.Click += new System.EventHandler(this.delay5SecondsToolStripMenuItem_Click);
+            // 
+            // delay10SecondsToolStripMenuItem
+            // 
+            this.delay10SecondsToolStripMenuItem.Name = "delay10SecondsToolStripMenuItem";
+            this.delay10SecondsToolStripMenuItem.Size = new System.Drawing.Size(165, 22);
+            this.delay10SecondsToolStripMenuItem.Text = "Delay 10 Seconds";
+            this.delay10SecondsToolStripMenuItem.Click += new System.EventHandler(this.delay10SecondsToolStripMenuItem_Click);
+            // 
+            // delay20SecondsToolStripMenuItem
+            // 
+            this.delay20SecondsToolStripMenuItem.Name = "delay20SecondsToolStripMenuItem";
+            this.delay20SecondsToolStripMenuItem.Size = new System.Drawing.Size(165, 22);
+            this.delay20SecondsToolStripMenuItem.Text = "Delay 20 Seconds";
+            this.delay20SecondsToolStripMenuItem.Click += new System.EventHandler(this.delay20SecondsToolStripMenuItem_Click);
+            // 
+            // delay30SecondsToolStripMenuItem
+            // 
+            this.delay30SecondsToolStripMenuItem.Name = "delay30SecondsToolStripMenuItem";
+            this.delay30SecondsToolStripMenuItem.Size = new System.Drawing.Size(165, 22);
+            this.delay30SecondsToolStripMenuItem.Text = "Delay 30 Seconds";
+            this.delay30SecondsToolStripMenuItem.Click += new System.EventHandler(this.delay30SecondsToolStripMenuItem_Click);
+            // 
+            // delay60SecondsToolStripMenuItem
+            // 
+            this.delay60SecondsToolStripMenuItem.Name = "delay60SecondsToolStripMenuItem";
+            this.delay60SecondsToolStripMenuItem.Size = new System.Drawing.Size(165, 22);
+            this.delay60SecondsToolStripMenuItem.Text = "Delay 60 Seconds";
+            this.delay60SecondsToolStripMenuItem.Click += new System.EventHandler(this.delay60SecondsToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator16
+            // 
+            this.toolStripSeparator16.Name = "toolStripSeparator16";
+            this.toolStripSeparator16.Size = new System.Drawing.Size(183, 6);
+            // 
+            // exportToolStripMenuItem
+            // 
+            this.exportToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.exportToolStripMenuItem.Name = "exportToolStripMenuItem";
+            this.exportToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
+            this.exportToolStripMenuItem.Text = "Export";
+            this.exportToolStripMenuItem.Click += new System.EventHandler(this.exportToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator1
+            // 
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
+            this.toolStripSeparator1.Size = new System.Drawing.Size(183, 6);
+            // 
+            // toolStripMenuItem_Close
+            // 
+            this.toolStripMenuItem_Close.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripMenuItem_Close.Name = "toolStripMenuItem_Close";
+            this.toolStripMenuItem_Close.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Q)));
+            this.toolStripMenuItem_Close.Size = new System.Drawing.Size(186, 22);
+            this.toolStripMenuItem_Close.Text = "Close";
+            this.toolStripMenuItem_Close.Click += new System.EventHandler(this.toolStripMenuItem_Close_Click);
+            // 
+            // editToolStripMenuItem
+            // 
+            this.editToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.addEffectToolStripMenuItem,
             this.toolStripSeparator2,
             this.toolStripMenuItem_Cut,
@@ -824,287 +827,289 @@ namespace VixenModules.Editor.TimedSequenceEditor
             this.toolStripMenuItem_SnapTo,
             this.toolStripMenuItem_ResizeIndicator,
             this.cADStyleSelectionBoxToolStripMenuItem});
-			this.editToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.editToolStripMenuItem.Name = "editToolStripMenuItem";
-			this.editToolStripMenuItem.Size = new System.Drawing.Size(39, 20);
-			this.editToolStripMenuItem.Text = "Edit";
-			// 
-			// addEffectToolStripMenuItem
-			// 
-			this.addEffectToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.addEffectToolStripMenuItem.Name = "addEffectToolStripMenuItem";
-			this.addEffectToolStripMenuItem.Size = new System.Drawing.Size(215, 22);
-			this.addEffectToolStripMenuItem.Text = "Add Effect";
-			// 
-			// toolStripSeparator2
-			// 
-			this.toolStripSeparator2.Name = "toolStripSeparator2";
-			this.toolStripSeparator2.Size = new System.Drawing.Size(212, 6);
-			// 
-			// toolStripMenuItem_Cut
-			// 
-			this.toolStripMenuItem_Cut.Enabled = false;
-			this.toolStripMenuItem_Cut.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripMenuItem_Cut.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-			this.toolStripMenuItem_Cut.Name = "toolStripMenuItem_Cut";
-			this.toolStripMenuItem_Cut.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X)));
-			this.toolStripMenuItem_Cut.Size = new System.Drawing.Size(215, 22);
-			this.toolStripMenuItem_Cut.Text = "Cut";
-			this.toolStripMenuItem_Cut.Click += new System.EventHandler(this.toolStripMenuItem_Cut_Click);
-			// 
-			// toolStripMenuItem_Copy
-			// 
-			this.toolStripMenuItem_Copy.Enabled = false;
-			this.toolStripMenuItem_Copy.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripMenuItem_Copy.Name = "toolStripMenuItem_Copy";
-			this.toolStripMenuItem_Copy.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-			this.toolStripMenuItem_Copy.Size = new System.Drawing.Size(215, 22);
-			this.toolStripMenuItem_Copy.Text = "Copy";
-			this.toolStripMenuItem_Copy.Click += new System.EventHandler(this.toolStripMenuItem_Copy_Click);
-			// 
-			// toolStripMenuItem_Paste
-			// 
-			this.toolStripMenuItem_Paste.Enabled = false;
-			this.toolStripMenuItem_Paste.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripMenuItem_Paste.Name = "toolStripMenuItem_Paste";
-			this.toolStripMenuItem_Paste.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
-			this.toolStripMenuItem_Paste.Size = new System.Drawing.Size(215, 22);
-			this.toolStripMenuItem_Paste.Text = "Paste";
-			this.toolStripMenuItem_Paste.Click += new System.EventHandler(this.toolStripMenuItem_Paste_Click);
-			// 
-			// toolStripSeparator8
-			// 
-			this.toolStripSeparator8.Name = "toolStripSeparator8";
-			this.toolStripSeparator8.Size = new System.Drawing.Size(212, 6);
-			// 
-			// undoToolStripMenuItem
-			// 
-			this.undoToolStripMenuItem.Name = "undoToolStripMenuItem";
-			this.undoToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Z)));
-			this.undoToolStripMenuItem.Size = new System.Drawing.Size(215, 22);
-			this.undoToolStripMenuItem.Text = "Undo";
-			this.undoToolStripMenuItem.Click += new System.EventHandler(this.undoToolStripMenuItem_Click);
-			// 
-			// redoToolStripMenuItem
-			// 
-			this.redoToolStripMenuItem.Name = "redoToolStripMenuItem";
-			this.redoToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Y)));
-			this.redoToolStripMenuItem.Size = new System.Drawing.Size(215, 22);
-			this.redoToolStripMenuItem.Text = "Redo";
-			this.redoToolStripMenuItem.Click += new System.EventHandler(this.redoToolStripMenuItem_Click);
-			// 
-			// toolStripSeparator3
-			// 
-			this.toolStripSeparator3.Name = "toolStripSeparator3";
-			this.toolStripSeparator3.Size = new System.Drawing.Size(212, 6);
-			// 
-			// selectAllElementsToolStripMenuItem
-			// 
-			this.selectAllElementsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.selectAllElementsToolStripMenuItem.Name = "selectAllElementsToolStripMenuItem";
-			this.selectAllElementsToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.A)));
-			this.selectAllElementsToolStripMenuItem.Size = new System.Drawing.Size(215, 22);
-			this.selectAllElementsToolStripMenuItem.Text = "Select All Elements";
-			this.selectAllElementsToolStripMenuItem.Click += new System.EventHandler(this.selectAllElementsToolStripMenuItem_Click);
-			// 
-			// toolStripMenuItem_deleteElements
-			// 
-			this.toolStripMenuItem_deleteElements.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripMenuItem_deleteElements.Name = "toolStripMenuItem_deleteElements";
-			this.toolStripMenuItem_deleteElements.ShortcutKeys = System.Windows.Forms.Keys.Delete;
-			this.toolStripMenuItem_deleteElements.Size = new System.Drawing.Size(215, 22);
-			this.toolStripMenuItem_deleteElements.Text = "Delete Element(s)";
-			this.toolStripMenuItem_deleteElements.Click += new System.EventHandler(this.toolStripMenuItem_deleteElements_Click);
-			// 
-			// toolStripSeparator10
-			// 
-			this.toolStripSeparator10.Name = "toolStripSeparator10";
-			this.toolStripSeparator10.Size = new System.Drawing.Size(212, 6);
-			// 
-			// toolStripMenuItem_SnapTo
-			// 
-			this.toolStripMenuItem_SnapTo.Checked = true;
-			this.toolStripMenuItem_SnapTo.CheckOnClick = true;
-			this.toolStripMenuItem_SnapTo.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.toolStripMenuItem_SnapTo.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.toolStripMenuItem_SnapTo.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripMenuItem_SnapTo.Name = "toolStripMenuItem_SnapTo";
-			this.toolStripMenuItem_SnapTo.Size = new System.Drawing.Size(215, 22);
-			this.toolStripMenuItem_SnapTo.Text = "Snap To Marks / Effects";
-			this.toolStripMenuItem_SnapTo.CheckedChanged += new System.EventHandler(this.toolStripMenuItem_SnapTo_CheckedChanged);
-			// 
-			// toolStripMenuItem_ResizeIndicator
-			// 
-			this.toolStripMenuItem_ResizeIndicator.CheckOnClick = true;
-			this.toolStripMenuItem_ResizeIndicator.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.editToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.editToolStripMenuItem.Name = "editToolStripMenuItem";
+            this.editToolStripMenuItem.Size = new System.Drawing.Size(39, 20);
+            this.editToolStripMenuItem.Text = "Edit";
+            // 
+            // addEffectToolStripMenuItem
+            // 
+            this.addEffectToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.addEffectToolStripMenuItem.Name = "addEffectToolStripMenuItem";
+            this.addEffectToolStripMenuItem.Size = new System.Drawing.Size(215, 22);
+            this.addEffectToolStripMenuItem.Text = "Add Effect";
+            // 
+            // toolStripSeparator2
+            // 
+            this.toolStripSeparator2.Name = "toolStripSeparator2";
+            this.toolStripSeparator2.Size = new System.Drawing.Size(212, 6);
+            // 
+            // toolStripMenuItem_Cut
+            // 
+            this.toolStripMenuItem_Cut.Enabled = false;
+            this.toolStripMenuItem_Cut.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripMenuItem_Cut.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.toolStripMenuItem_Cut.Name = "toolStripMenuItem_Cut";
+            this.toolStripMenuItem_Cut.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X)));
+            this.toolStripMenuItem_Cut.Size = new System.Drawing.Size(215, 22);
+            this.toolStripMenuItem_Cut.Text = "Cut";
+            this.toolStripMenuItem_Cut.Click += new System.EventHandler(this.toolStripMenuItem_Cut_Click);
+            // 
+            // toolStripMenuItem_Copy
+            // 
+            this.toolStripMenuItem_Copy.Enabled = false;
+            this.toolStripMenuItem_Copy.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripMenuItem_Copy.Name = "toolStripMenuItem_Copy";
+            this.toolStripMenuItem_Copy.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
+            this.toolStripMenuItem_Copy.Size = new System.Drawing.Size(215, 22);
+            this.toolStripMenuItem_Copy.Text = "Copy";
+            this.toolStripMenuItem_Copy.Click += new System.EventHandler(this.toolStripMenuItem_Copy_Click);
+            // 
+            // toolStripMenuItem_Paste
+            // 
+            this.toolStripMenuItem_Paste.Enabled = false;
+            this.toolStripMenuItem_Paste.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripMenuItem_Paste.Name = "toolStripMenuItem_Paste";
+            this.toolStripMenuItem_Paste.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
+            this.toolStripMenuItem_Paste.Size = new System.Drawing.Size(215, 22);
+            this.toolStripMenuItem_Paste.Text = "Paste";
+            this.toolStripMenuItem_Paste.Click += new System.EventHandler(this.toolStripMenuItem_Paste_Click);
+            // 
+            // toolStripSeparator8
+            // 
+            this.toolStripSeparator8.Name = "toolStripSeparator8";
+            this.toolStripSeparator8.Size = new System.Drawing.Size(212, 6);
+            // 
+            // undoToolStripMenuItem
+            // 
+            this.undoToolStripMenuItem.Name = "undoToolStripMenuItem";
+            this.undoToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Z)));
+            this.undoToolStripMenuItem.Size = new System.Drawing.Size(215, 22);
+            this.undoToolStripMenuItem.Text = "Undo";
+            this.undoToolStripMenuItem.Click += new System.EventHandler(this.undoToolStripMenuItem_Click);
+            // 
+            // redoToolStripMenuItem
+            // 
+            this.redoToolStripMenuItem.Name = "redoToolStripMenuItem";
+            this.redoToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Y)));
+            this.redoToolStripMenuItem.Size = new System.Drawing.Size(215, 22);
+            this.redoToolStripMenuItem.Text = "Redo";
+            this.redoToolStripMenuItem.Click += new System.EventHandler(this.redoToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator3
+            // 
+            this.toolStripSeparator3.Name = "toolStripSeparator3";
+            this.toolStripSeparator3.Size = new System.Drawing.Size(212, 6);
+            // 
+            // selectAllElementsToolStripMenuItem
+            // 
+            this.selectAllElementsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.selectAllElementsToolStripMenuItem.Name = "selectAllElementsToolStripMenuItem";
+            this.selectAllElementsToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.A)));
+            this.selectAllElementsToolStripMenuItem.Size = new System.Drawing.Size(215, 22);
+            this.selectAllElementsToolStripMenuItem.Text = "Select All Elements";
+            this.selectAllElementsToolStripMenuItem.Click += new System.EventHandler(this.selectAllElementsToolStripMenuItem_Click);
+            // 
+            // toolStripMenuItem_deleteElements
+            // 
+            this.toolStripMenuItem_deleteElements.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripMenuItem_deleteElements.Name = "toolStripMenuItem_deleteElements";
+            this.toolStripMenuItem_deleteElements.ShortcutKeys = System.Windows.Forms.Keys.Delete;
+            this.toolStripMenuItem_deleteElements.Size = new System.Drawing.Size(215, 22);
+            this.toolStripMenuItem_deleteElements.Text = "Delete Element(s)";
+            this.toolStripMenuItem_deleteElements.Click += new System.EventHandler(this.toolStripMenuItem_deleteElements_Click);
+            // 
+            // toolStripSeparator10
+            // 
+            this.toolStripSeparator10.Name = "toolStripSeparator10";
+            this.toolStripSeparator10.Size = new System.Drawing.Size(212, 6);
+            // 
+            // toolStripMenuItem_SnapTo
+            // 
+            this.toolStripMenuItem_SnapTo.Checked = true;
+            this.toolStripMenuItem_SnapTo.CheckOnClick = true;
+            this.toolStripMenuItem_SnapTo.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.toolStripMenuItem_SnapTo.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripMenuItem_SnapTo.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripMenuItem_SnapTo.Name = "toolStripMenuItem_SnapTo";
+            this.toolStripMenuItem_SnapTo.Size = new System.Drawing.Size(215, 22);
+            this.toolStripMenuItem_SnapTo.Text = "Snap To Marks / Effects";
+            this.toolStripMenuItem_SnapTo.CheckedChanged += new System.EventHandler(this.toolStripMenuItem_SnapTo_CheckedChanged);
+            // 
+            // toolStripMenuItem_ResizeIndicator
+            // 
+            this.toolStripMenuItem_ResizeIndicator.CheckOnClick = true;
+            this.toolStripMenuItem_ResizeIndicator.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItem_RIColor_Blue,
             this.toolStripMenuItem_RIColor_Yellow,
             this.toolStripMenuItem_RIColor_Green,
             this.toolStripMenuItem_RIColor_White,
             this.toolStripMenuItem_RIColor_Red});
-			this.toolStripMenuItem_ResizeIndicator.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripMenuItem_ResizeIndicator.Name = "toolStripMenuItem_ResizeIndicator";
-			this.toolStripMenuItem_ResizeIndicator.Size = new System.Drawing.Size(215, 22);
-			this.toolStripMenuItem_ResizeIndicator.Text = "Resize / Draw Indicator";
-			this.toolStripMenuItem_ResizeIndicator.CheckStateChanged += new System.EventHandler(this.toolStripMenuItem_ResizeIndicator_CheckStateChanged);
-			// 
-			// toolStripMenuItem_RIColor_Blue
-			// 
-			this.toolStripMenuItem_RIColor_Blue.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripMenuItem_RIColor_Blue.Name = "toolStripMenuItem_RIColor_Blue";
-			this.toolStripMenuItem_RIColor_Blue.Size = new System.Drawing.Size(109, 22);
-			this.toolStripMenuItem_RIColor_Blue.Text = "Blue";
-			this.toolStripMenuItem_RIColor_Blue.Click += new System.EventHandler(this.toolStripMenuItem_RIColor_Blue_Click);
-			// 
-			// toolStripMenuItem_RIColor_Yellow
-			// 
-			this.toolStripMenuItem_RIColor_Yellow.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripMenuItem_RIColor_Yellow.Name = "toolStripMenuItem_RIColor_Yellow";
-			this.toolStripMenuItem_RIColor_Yellow.Size = new System.Drawing.Size(109, 22);
-			this.toolStripMenuItem_RIColor_Yellow.Text = "Yellow";
-			this.toolStripMenuItem_RIColor_Yellow.Click += new System.EventHandler(this.toolStripMenuItem_RIColor_Yellow_Click);
-			// 
-			// toolStripMenuItem_RIColor_Green
-			// 
-			this.toolStripMenuItem_RIColor_Green.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripMenuItem_RIColor_Green.Name = "toolStripMenuItem_RIColor_Green";
-			this.toolStripMenuItem_RIColor_Green.Size = new System.Drawing.Size(109, 22);
-			this.toolStripMenuItem_RIColor_Green.Text = "Green";
-			this.toolStripMenuItem_RIColor_Green.Click += new System.EventHandler(this.toolStripMenuItem_RIColor_Green_Click);
-			// 
-			// toolStripMenuItem_RIColor_White
-			// 
-			this.toolStripMenuItem_RIColor_White.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripMenuItem_RIColor_White.Name = "toolStripMenuItem_RIColor_White";
-			this.toolStripMenuItem_RIColor_White.Size = new System.Drawing.Size(109, 22);
-			this.toolStripMenuItem_RIColor_White.Text = "White";
-			this.toolStripMenuItem_RIColor_White.Click += new System.EventHandler(this.toolStripMenuItem_RIColor_White_Click);
-			// 
-			// toolStripMenuItem_RIColor_Red
-			// 
-			this.toolStripMenuItem_RIColor_Red.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripMenuItem_RIColor_Red.Name = "toolStripMenuItem_RIColor_Red";
-			this.toolStripMenuItem_RIColor_Red.Size = new System.Drawing.Size(109, 22);
-			this.toolStripMenuItem_RIColor_Red.Text = "Red";
-			this.toolStripMenuItem_RIColor_Red.Click += new System.EventHandler(this.toolStripMenuItem_RIColor_Red_Click);
-			// 
-			// cADStyleSelectionBoxToolStripMenuItem
-			// 
-			this.cADStyleSelectionBoxToolStripMenuItem.CheckOnClick = true;
-			this.cADStyleSelectionBoxToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.cADStyleSelectionBoxToolStripMenuItem.Name = "cADStyleSelectionBoxToolStripMenuItem";
-			this.cADStyleSelectionBoxToolStripMenuItem.Size = new System.Drawing.Size(215, 22);
-			this.cADStyleSelectionBoxToolStripMenuItem.Text = "CAD Style Selection Box";
-			this.cADStyleSelectionBoxToolStripMenuItem.Click += new System.EventHandler(this.cADStyleSelectionBoxToolStripMenuItem_Click);
-			// 
-			// viewToolStripMenuItem
-			// 
-			this.viewToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItem_ResizeIndicator.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripMenuItem_ResizeIndicator.Name = "toolStripMenuItem_ResizeIndicator";
+            this.toolStripMenuItem_ResizeIndicator.Size = new System.Drawing.Size(215, 22);
+            this.toolStripMenuItem_ResizeIndicator.Text = "Resize / Draw Indicator";
+            this.toolStripMenuItem_ResizeIndicator.CheckStateChanged += new System.EventHandler(this.toolStripMenuItem_ResizeIndicator_CheckStateChanged);
+            // 
+            // toolStripMenuItem_RIColor_Blue
+            // 
+            this.toolStripMenuItem_RIColor_Blue.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripMenuItem_RIColor_Blue.Name = "toolStripMenuItem_RIColor_Blue";
+            this.toolStripMenuItem_RIColor_Blue.Size = new System.Drawing.Size(108, 22);
+            this.toolStripMenuItem_RIColor_Blue.Text = "Blue";
+            this.toolStripMenuItem_RIColor_Blue.Click += new System.EventHandler(this.toolStripMenuItem_RIColor_Blue_Click);
+            // 
+            // toolStripMenuItem_RIColor_Yellow
+            // 
+            this.toolStripMenuItem_RIColor_Yellow.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripMenuItem_RIColor_Yellow.Name = "toolStripMenuItem_RIColor_Yellow";
+            this.toolStripMenuItem_RIColor_Yellow.Size = new System.Drawing.Size(108, 22);
+            this.toolStripMenuItem_RIColor_Yellow.Text = "Yellow";
+            this.toolStripMenuItem_RIColor_Yellow.Click += new System.EventHandler(this.toolStripMenuItem_RIColor_Yellow_Click);
+            // 
+            // toolStripMenuItem_RIColor_Green
+            // 
+            this.toolStripMenuItem_RIColor_Green.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripMenuItem_RIColor_Green.Name = "toolStripMenuItem_RIColor_Green";
+            this.toolStripMenuItem_RIColor_Green.Size = new System.Drawing.Size(108, 22);
+            this.toolStripMenuItem_RIColor_Green.Text = "Green";
+            this.toolStripMenuItem_RIColor_Green.Click += new System.EventHandler(this.toolStripMenuItem_RIColor_Green_Click);
+            // 
+            // toolStripMenuItem_RIColor_White
+            // 
+            this.toolStripMenuItem_RIColor_White.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripMenuItem_RIColor_White.Name = "toolStripMenuItem_RIColor_White";
+            this.toolStripMenuItem_RIColor_White.Size = new System.Drawing.Size(108, 22);
+            this.toolStripMenuItem_RIColor_White.Text = "White";
+            this.toolStripMenuItem_RIColor_White.Click += new System.EventHandler(this.toolStripMenuItem_RIColor_White_Click);
+            // 
+            // toolStripMenuItem_RIColor_Red
+            // 
+            this.toolStripMenuItem_RIColor_Red.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripMenuItem_RIColor_Red.Name = "toolStripMenuItem_RIColor_Red";
+            this.toolStripMenuItem_RIColor_Red.Size = new System.Drawing.Size(108, 22);
+            this.toolStripMenuItem_RIColor_Red.Text = "Red";
+            this.toolStripMenuItem_RIColor_Red.Click += new System.EventHandler(this.toolStripMenuItem_RIColor_Red_Click);
+            // 
+            // cADStyleSelectionBoxToolStripMenuItem
+            // 
+            this.cADStyleSelectionBoxToolStripMenuItem.CheckOnClick = true;
+            this.cADStyleSelectionBoxToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.cADStyleSelectionBoxToolStripMenuItem.Name = "cADStyleSelectionBoxToolStripMenuItem";
+            this.cADStyleSelectionBoxToolStripMenuItem.Size = new System.Drawing.Size(215, 22);
+            this.cADStyleSelectionBoxToolStripMenuItem.Text = "CAD Style Selection Box";
+            this.cADStyleSelectionBoxToolStripMenuItem.Click += new System.EventHandler(this.cADStyleSelectionBoxToolStripMenuItem_Click);
+            // 
+            // viewToolStripMenuItem
+            // 
+            this.viewToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItem_zoomTimeIn,
             this.toolStripMenuItem_zoomTimeOut,
             this.toolStripMenuItem_zoomRowsIn,
             this.toolStripMenuItem_zoomRowsOut,
+            this.toolStripMenuItem_expandAllRows,
+            this.toolStripMenuItem_contractAllRows,
             this.toolStripMenuItem1,
             this.effectWindowToolStripMenuItem,
             this.markWindowToolStripMenuItem,
             this.toolWindowToolStripMenuItem,
             this.gridWindowToolStripMenuItem,
             this.effectEditorWindowToolStripMenuItem});
-			this.viewToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.viewToolStripMenuItem.Name = "viewToolStripMenuItem";
-			this.viewToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
-			this.viewToolStripMenuItem.Text = "View";
-			// 
-			// toolStripMenuItem_zoomTimeIn
-			// 
-			this.toolStripMenuItem_zoomTimeIn.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripMenuItem_zoomTimeIn.Name = "toolStripMenuItem_zoomTimeIn";
-			this.toolStripMenuItem_zoomTimeIn.ShortcutKeyDisplayString = "Ctrl+ +";
-			this.toolStripMenuItem_zoomTimeIn.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Add)));
-			this.toolStripMenuItem_zoomTimeIn.Size = new System.Drawing.Size(234, 22);
-			this.toolStripMenuItem_zoomTimeIn.Text = "Zoom Time In";
-			this.toolStripMenuItem_zoomTimeIn.Click += new System.EventHandler(this.toolStripMenuItem_zoomTimeIn_Click);
-			// 
-			// toolStripMenuItem_zoomTimeOut
-			// 
-			this.toolStripMenuItem_zoomTimeOut.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripMenuItem_zoomTimeOut.Name = "toolStripMenuItem_zoomTimeOut";
-			this.toolStripMenuItem_zoomTimeOut.ShortcutKeyDisplayString = "Ctrl+ -";
-			this.toolStripMenuItem_zoomTimeOut.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Subtract)));
-			this.toolStripMenuItem_zoomTimeOut.Size = new System.Drawing.Size(234, 22);
-			this.toolStripMenuItem_zoomTimeOut.Text = "Zoom Time Out";
-			this.toolStripMenuItem_zoomTimeOut.Click += new System.EventHandler(this.toolStripMenuItem_zoomTimeOut_Click);
-			// 
-			// toolStripMenuItem_zoomRowsIn
-			// 
-			this.toolStripMenuItem_zoomRowsIn.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripMenuItem_zoomRowsIn.Name = "toolStripMenuItem_zoomRowsIn";
-			this.toolStripMenuItem_zoomRowsIn.ShortcutKeyDisplayString = "Ctrl+Shift+ +";
-			this.toolStripMenuItem_zoomRowsIn.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+            this.viewToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.viewToolStripMenuItem.Name = "viewToolStripMenuItem";
+            this.viewToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
+            this.viewToolStripMenuItem.Text = "View";
+            // 
+            // toolStripMenuItem_zoomTimeIn
+            // 
+            this.toolStripMenuItem_zoomTimeIn.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripMenuItem_zoomTimeIn.Name = "toolStripMenuItem_zoomTimeIn";
+            this.toolStripMenuItem_zoomTimeIn.ShortcutKeyDisplayString = "Ctrl+ +";
+            this.toolStripMenuItem_zoomTimeIn.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Add)));
+            this.toolStripMenuItem_zoomTimeIn.Size = new System.Drawing.Size(234, 22);
+            this.toolStripMenuItem_zoomTimeIn.Text = "Zoom Time In";
+            this.toolStripMenuItem_zoomTimeIn.Click += new System.EventHandler(this.toolStripMenuItem_zoomTimeIn_Click);
+            // 
+            // toolStripMenuItem_zoomTimeOut
+            // 
+            this.toolStripMenuItem_zoomTimeOut.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripMenuItem_zoomTimeOut.Name = "toolStripMenuItem_zoomTimeOut";
+            this.toolStripMenuItem_zoomTimeOut.ShortcutKeyDisplayString = "Ctrl+ -";
+            this.toolStripMenuItem_zoomTimeOut.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Subtract)));
+            this.toolStripMenuItem_zoomTimeOut.Size = new System.Drawing.Size(234, 22);
+            this.toolStripMenuItem_zoomTimeOut.Text = "Zoom Time Out";
+            this.toolStripMenuItem_zoomTimeOut.Click += new System.EventHandler(this.toolStripMenuItem_zoomTimeOut_Click);
+            // 
+            // toolStripMenuItem_zoomRowsIn
+            // 
+            this.toolStripMenuItem_zoomRowsIn.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripMenuItem_zoomRowsIn.Name = "toolStripMenuItem_zoomRowsIn";
+            this.toolStripMenuItem_zoomRowsIn.ShortcutKeyDisplayString = "Ctrl+Shift+ +";
+            this.toolStripMenuItem_zoomRowsIn.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.Add)));
-			this.toolStripMenuItem_zoomRowsIn.Size = new System.Drawing.Size(234, 22);
-			this.toolStripMenuItem_zoomRowsIn.Text = "Zoom Rows In";
-			this.toolStripMenuItem_zoomRowsIn.Click += new System.EventHandler(this.toolStripMenuItem_zoomRowsIn_Click);
-			// 
-			// toolStripMenuItem_zoomRowsOut
-			// 
-			this.toolStripMenuItem_zoomRowsOut.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripMenuItem_zoomRowsOut.Name = "toolStripMenuItem_zoomRowsOut";
-			this.toolStripMenuItem_zoomRowsOut.ShortcutKeyDisplayString = "Ctrl+Shift+ -";
-			this.toolStripMenuItem_zoomRowsOut.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+            this.toolStripMenuItem_zoomRowsIn.Size = new System.Drawing.Size(234, 22);
+            this.toolStripMenuItem_zoomRowsIn.Text = "Zoom Rows In";
+            this.toolStripMenuItem_zoomRowsIn.Click += new System.EventHandler(this.toolStripMenuItem_zoomRowsIn_Click);
+            // 
+            // toolStripMenuItem_zoomRowsOut
+            // 
+            this.toolStripMenuItem_zoomRowsOut.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripMenuItem_zoomRowsOut.Name = "toolStripMenuItem_zoomRowsOut";
+            this.toolStripMenuItem_zoomRowsOut.ShortcutKeyDisplayString = "Ctrl+Shift+ -";
+            this.toolStripMenuItem_zoomRowsOut.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.Subtract)));
-			this.toolStripMenuItem_zoomRowsOut.Size = new System.Drawing.Size(234, 22);
-			this.toolStripMenuItem_zoomRowsOut.Text = "Zoom Rows Out";
-			this.toolStripMenuItem_zoomRowsOut.Click += new System.EventHandler(this.toolStripMenuItem_zoomRowsOut_Click);
-			// 
-			// toolStripMenuItem1
-			// 
-			this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-			this.toolStripMenuItem1.Size = new System.Drawing.Size(231, 6);
-			// 
-			// effectWindowToolStripMenuItem
-			// 
-			this.effectWindowToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.effectWindowToolStripMenuItem.Name = "effectWindowToolStripMenuItem";
-			this.effectWindowToolStripMenuItem.Size = new System.Drawing.Size(234, 22);
-			this.effectWindowToolStripMenuItem.Text = "Effect Window";
-			this.effectWindowToolStripMenuItem.Click += new System.EventHandler(this.effectWindowToolStripMenuItem_Click);
-			// 
-			// markWindowToolStripMenuItem
-			// 
-			this.markWindowToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.markWindowToolStripMenuItem.Name = "markWindowToolStripMenuItem";
-			this.markWindowToolStripMenuItem.Size = new System.Drawing.Size(234, 22);
-			this.markWindowToolStripMenuItem.Text = "Mark Window";
-			this.markWindowToolStripMenuItem.Click += new System.EventHandler(this.markWindowToolStripMenuItem_Click);
-			// 
-			// toolWindowToolStripMenuItem
-			// 
-			this.toolWindowToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolWindowToolStripMenuItem.Name = "toolWindowToolStripMenuItem";
-			this.toolWindowToolStripMenuItem.Size = new System.Drawing.Size(234, 22);
-			this.toolWindowToolStripMenuItem.Text = "Preset Window";
-			this.toolWindowToolStripMenuItem.Click += new System.EventHandler(this.toolWindowToolStripMenuItem_Click);
-			// 
-			// gridWindowToolStripMenuItem
-			// 
-			this.gridWindowToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.gridWindowToolStripMenuItem.Name = "gridWindowToolStripMenuItem";
-			this.gridWindowToolStripMenuItem.Size = new System.Drawing.Size(234, 22);
-			this.gridWindowToolStripMenuItem.Text = "Timeline Window";
-			this.gridWindowToolStripMenuItem.Click += new System.EventHandler(this.gridWindowToolStripMenuItem_Click);
-			// 
-			// effectEditorWindowToolStripMenuItem
-			// 
-			this.effectEditorWindowToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.effectEditorWindowToolStripMenuItem.Name = "effectEditorWindowToolStripMenuItem";
-			this.effectEditorWindowToolStripMenuItem.Size = new System.Drawing.Size(234, 22);
-			this.effectEditorWindowToolStripMenuItem.Text = "Effect Editor Window";
-			this.effectEditorWindowToolStripMenuItem.Click += new System.EventHandler(this.effectEditorWindowToolStripMenuItem_Click);
-			// 
-			// toolsToolStripMenuItem
-			// 
-			this.toolsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItem_zoomRowsOut.Size = new System.Drawing.Size(234, 22);
+            this.toolStripMenuItem_zoomRowsOut.Text = "Zoom Rows Out";
+            this.toolStripMenuItem_zoomRowsOut.Click += new System.EventHandler(this.toolStripMenuItem_zoomRowsOut_Click);
+            // 
+            // toolStripMenuItem1
+            // 
+            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(231, 6);
+            // 
+            // effectWindowToolStripMenuItem
+            // 
+            this.effectWindowToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.effectWindowToolStripMenuItem.Name = "effectWindowToolStripMenuItem";
+            this.effectWindowToolStripMenuItem.Size = new System.Drawing.Size(234, 22);
+            this.effectWindowToolStripMenuItem.Text = "Effect Window";
+            this.effectWindowToolStripMenuItem.Click += new System.EventHandler(this.effectWindowToolStripMenuItem_Click);
+            // 
+            // markWindowToolStripMenuItem
+            // 
+            this.markWindowToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.markWindowToolStripMenuItem.Name = "markWindowToolStripMenuItem";
+            this.markWindowToolStripMenuItem.Size = new System.Drawing.Size(234, 22);
+            this.markWindowToolStripMenuItem.Text = "Mark Window";
+            this.markWindowToolStripMenuItem.Click += new System.EventHandler(this.markWindowToolStripMenuItem_Click);
+            // 
+            // toolWindowToolStripMenuItem
+            // 
+            this.toolWindowToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolWindowToolStripMenuItem.Name = "toolWindowToolStripMenuItem";
+            this.toolWindowToolStripMenuItem.Size = new System.Drawing.Size(234, 22);
+            this.toolWindowToolStripMenuItem.Text = "Preset Window";
+            this.toolWindowToolStripMenuItem.Click += new System.EventHandler(this.toolWindowToolStripMenuItem_Click);
+            // 
+            // gridWindowToolStripMenuItem
+            // 
+            this.gridWindowToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.gridWindowToolStripMenuItem.Name = "gridWindowToolStripMenuItem";
+            this.gridWindowToolStripMenuItem.Size = new System.Drawing.Size(234, 22);
+            this.gridWindowToolStripMenuItem.Text = "Timeline Window";
+            this.gridWindowToolStripMenuItem.Click += new System.EventHandler(this.gridWindowToolStripMenuItem_Click);
+            // 
+            // effectEditorWindowToolStripMenuItem
+            // 
+            this.effectEditorWindowToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.effectEditorWindowToolStripMenuItem.Name = "effectEditorWindowToolStripMenuItem";
+            this.effectEditorWindowToolStripMenuItem.Size = new System.Drawing.Size(234, 22);
+            this.effectEditorWindowToolStripMenuItem.Text = "Effect Editor Window";
+            this.effectEditorWindowToolStripMenuItem.Click += new System.EventHandler(this.effectEditorWindowToolStripMenuItem_Click);
+            // 
+            // toolsToolStripMenuItem
+            // 
+            this.toolsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.audioToolStripMenuItem,
             this.toolStripMenuItem_MarkManager,
             this.modifySequenceLengthToolStripMenuItem,
@@ -1113,174 +1118,174 @@ namespace VixenModules.Editor.TimedSequenceEditor
             this.ColorCollectionsToolStripMenuItem,
             this.lipSyncMappingsToolStripMenuItem,
             this.bulkEffectMoveToolStripMenuItem});
-			this.toolsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
-			this.toolsToolStripMenuItem.Size = new System.Drawing.Size(48, 20);
-			this.toolsToolStripMenuItem.Text = "Tools";
-			// 
-			// audioToolStripMenuItem
-			// 
-			this.audioToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
+            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(47, 20);
+            this.toolsToolStripMenuItem.Text = "Tools";
+            // 
+            // audioToolStripMenuItem
+            // 
+            this.audioToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItem_associateAudio,
             this.toolStripMenuItem_removeAudio,
             this.toolStripSeparator7,
             this.beatBarDetectionToolStripMenuItem});
-			this.audioToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.audioToolStripMenuItem.Name = "audioToolStripMenuItem";
-			this.audioToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
-			this.audioToolStripMenuItem.Text = "Audio";
-			// 
-			// toolStripMenuItem_associateAudio
-			// 
-			this.toolStripMenuItem_associateAudio.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripMenuItem_associateAudio.Name = "toolStripMenuItem_associateAudio";
-			this.toolStripMenuItem_associateAudio.Size = new System.Drawing.Size(173, 22);
-			this.toolStripMenuItem_associateAudio.Text = "Associate Audio...";
-			this.toolStripMenuItem_associateAudio.Click += new System.EventHandler(this.toolStripMenuItem_associateAudio_Click);
-			// 
-			// toolStripMenuItem_removeAudio
-			// 
-			this.toolStripMenuItem_removeAudio.Enabled = false;
-			this.toolStripMenuItem_removeAudio.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripMenuItem_removeAudio.Name = "toolStripMenuItem_removeAudio";
-			this.toolStripMenuItem_removeAudio.Size = new System.Drawing.Size(173, 22);
-			this.toolStripMenuItem_removeAudio.Text = "Remove Audio";
-			this.toolStripMenuItem_removeAudio.Click += new System.EventHandler(this.toolStripMenuItem_removeAudio_Click);
-			// 
-			// toolStripSeparator7
-			// 
-			this.toolStripSeparator7.Name = "toolStripSeparator7";
-			this.toolStripSeparator7.Size = new System.Drawing.Size(170, 6);
-			// 
-			// beatBarDetectionToolStripMenuItem
-			// 
-			this.beatBarDetectionToolStripMenuItem.Enabled = false;
-			this.beatBarDetectionToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.beatBarDetectionToolStripMenuItem.Name = "beatBarDetectionToolStripMenuItem";
-			this.beatBarDetectionToolStripMenuItem.Size = new System.Drawing.Size(173, 22);
-			this.beatBarDetectionToolStripMenuItem.Text = "Beat/Bar Detection";
-			this.beatBarDetectionToolStripMenuItem.Click += new System.EventHandler(this.toolStripMenuItem_BeatBarDetection_Click);
-			// 
-			// toolStripMenuItem_MarkManager
-			// 
-			this.toolStripMenuItem_MarkManager.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripMenuItem_MarkManager.Name = "toolStripMenuItem_MarkManager";
-			this.toolStripMenuItem_MarkManager.Size = new System.Drawing.Size(194, 22);
-			this.toolStripMenuItem_MarkManager.Text = "Mark Manager...";
-			this.toolStripMenuItem_MarkManager.Click += new System.EventHandler(this.toolStripMenuItem_MarkManager_Click);
-			// 
-			// modifySequenceLengthToolStripMenuItem
-			// 
-			this.modifySequenceLengthToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.modifySequenceLengthToolStripMenuItem.Name = "modifySequenceLengthToolStripMenuItem";
-			this.modifySequenceLengthToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
-			this.modifySequenceLengthToolStripMenuItem.Text = "Sequence Length...";
-			this.modifySequenceLengthToolStripMenuItem.Click += new System.EventHandler(this.modifySequenceLengthToolStripMenuItem_Click);
-			// 
-			// curveEditorToolStripMenuItem
-			// 
-			this.curveEditorToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.curveEditorToolStripMenuItem.Name = "curveEditorToolStripMenuItem";
-			this.curveEditorToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
-			this.curveEditorToolStripMenuItem.Text = "Curve Editor";
-			this.curveEditorToolStripMenuItem.Click += new System.EventHandler(this.curveEditorToolStripMenuItem_Click);
-			// 
-			// colorGradientEditorToolStripMenuItem
-			// 
-			this.colorGradientEditorToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.colorGradientEditorToolStripMenuItem.Name = "colorGradientEditorToolStripMenuItem";
-			this.colorGradientEditorToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
-			this.colorGradientEditorToolStripMenuItem.Text = "Color Gradient Editor";
-			this.colorGradientEditorToolStripMenuItem.Click += new System.EventHandler(this.colorGradientToolStripMenuItem_Click);
-			// 
-			// ColorCollectionsToolStripMenuItem
-			// 
-			this.ColorCollectionsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.ColorCollectionsToolStripMenuItem.Name = "ColorCollectionsToolStripMenuItem";
-			this.ColorCollectionsToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
-			this.ColorCollectionsToolStripMenuItem.Text = "Color Collection Editor";
-			this.ColorCollectionsToolStripMenuItem.Click += new System.EventHandler(this.ColorCollectionsToolStripMenuItem_Click);
-			// 
-			// lipSyncMappingsToolStripMenuItem
-			// 
-			this.lipSyncMappingsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.audioToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.audioToolStripMenuItem.Name = "audioToolStripMenuItem";
+            this.audioToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
+            this.audioToolStripMenuItem.Text = "Audio";
+            // 
+            // toolStripMenuItem_associateAudio
+            // 
+            this.toolStripMenuItem_associateAudio.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripMenuItem_associateAudio.Name = "toolStripMenuItem_associateAudio";
+            this.toolStripMenuItem_associateAudio.Size = new System.Drawing.Size(173, 22);
+            this.toolStripMenuItem_associateAudio.Text = "Associate Audio...";
+            this.toolStripMenuItem_associateAudio.Click += new System.EventHandler(this.toolStripMenuItem_associateAudio_Click);
+            // 
+            // toolStripMenuItem_removeAudio
+            // 
+            this.toolStripMenuItem_removeAudio.Enabled = false;
+            this.toolStripMenuItem_removeAudio.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripMenuItem_removeAudio.Name = "toolStripMenuItem_removeAudio";
+            this.toolStripMenuItem_removeAudio.Size = new System.Drawing.Size(173, 22);
+            this.toolStripMenuItem_removeAudio.Text = "Remove Audio";
+            this.toolStripMenuItem_removeAudio.Click += new System.EventHandler(this.toolStripMenuItem_removeAudio_Click);
+            // 
+            // toolStripSeparator7
+            // 
+            this.toolStripSeparator7.Name = "toolStripSeparator7";
+            this.toolStripSeparator7.Size = new System.Drawing.Size(170, 6);
+            // 
+            // beatBarDetectionToolStripMenuItem
+            // 
+            this.beatBarDetectionToolStripMenuItem.Enabled = false;
+            this.beatBarDetectionToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.beatBarDetectionToolStripMenuItem.Name = "beatBarDetectionToolStripMenuItem";
+            this.beatBarDetectionToolStripMenuItem.Size = new System.Drawing.Size(173, 22);
+            this.beatBarDetectionToolStripMenuItem.Text = "Beat/Bar Detection";
+            this.beatBarDetectionToolStripMenuItem.Click += new System.EventHandler(this.toolStripMenuItem_BeatBarDetection_Click);
+            // 
+            // toolStripMenuItem_MarkManager
+            // 
+            this.toolStripMenuItem_MarkManager.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripMenuItem_MarkManager.Name = "toolStripMenuItem_MarkManager";
+            this.toolStripMenuItem_MarkManager.Size = new System.Drawing.Size(194, 22);
+            this.toolStripMenuItem_MarkManager.Text = "Mark Manager...";
+            this.toolStripMenuItem_MarkManager.Click += new System.EventHandler(this.toolStripMenuItem_MarkManager_Click);
+            // 
+            // modifySequenceLengthToolStripMenuItem
+            // 
+            this.modifySequenceLengthToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.modifySequenceLengthToolStripMenuItem.Name = "modifySequenceLengthToolStripMenuItem";
+            this.modifySequenceLengthToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
+            this.modifySequenceLengthToolStripMenuItem.Text = "Sequence Length...";
+            this.modifySequenceLengthToolStripMenuItem.Click += new System.EventHandler(this.modifySequenceLengthToolStripMenuItem_Click);
+            // 
+            // curveEditorToolStripMenuItem
+            // 
+            this.curveEditorToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.curveEditorToolStripMenuItem.Name = "curveEditorToolStripMenuItem";
+            this.curveEditorToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
+            this.curveEditorToolStripMenuItem.Text = "Curve Editor";
+            this.curveEditorToolStripMenuItem.Click += new System.EventHandler(this.curveEditorToolStripMenuItem_Click);
+            // 
+            // colorGradientEditorToolStripMenuItem
+            // 
+            this.colorGradientEditorToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.colorGradientEditorToolStripMenuItem.Name = "colorGradientEditorToolStripMenuItem";
+            this.colorGradientEditorToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
+            this.colorGradientEditorToolStripMenuItem.Text = "Color Gradient Editor";
+            this.colorGradientEditorToolStripMenuItem.Click += new System.EventHandler(this.colorGradientToolStripMenuItem_Click);
+            // 
+            // ColorCollectionsToolStripMenuItem
+            // 
+            this.ColorCollectionsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.ColorCollectionsToolStripMenuItem.Name = "ColorCollectionsToolStripMenuItem";
+            this.ColorCollectionsToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
+            this.ColorCollectionsToolStripMenuItem.Text = "Color Collection Editor";
+            this.ColorCollectionsToolStripMenuItem.Click += new System.EventHandler(this.ColorCollectionsToolStripMenuItem_Click);
+            // 
+            // lipSyncMappingsToolStripMenuItem
+            // 
+            this.lipSyncMappingsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.defaultMapToolStripMenuItem,
             this.phonemeMappingsToolStripMenuItem,
             this.changeMapToolStripMenuItem,
             this.lyricConverterToolStripMenuItem,
             this.papagayoImportToolStripMenuItem});
-			this.lipSyncMappingsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.lipSyncMappingsToolStripMenuItem.Name = "lipSyncMappingsToolStripMenuItem";
-			this.lipSyncMappingsToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
-			this.lipSyncMappingsToolStripMenuItem.Text = "LipSync";
-			this.lipSyncMappingsToolStripMenuItem.DropDownOpening += new System.EventHandler(this.lipSyncMappingsToolStripMenuItem_DropDownOpening);
-			// 
-			// defaultMapToolStripMenuItem
-			// 
-			this.defaultMapToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.defaultMapToolStripMenuItem.Name = "defaultMapToolStripMenuItem";
-			this.defaultMapToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
-			this.defaultMapToolStripMenuItem.Text = "Default Map";
-			this.defaultMapToolStripMenuItem.DropDownOpening += new System.EventHandler(this.defaultMapToolStripMenuItem_DropDownOpening);
-			// 
-			// phonemeMappingsToolStripMenuItem
-			// 
-			this.phonemeMappingsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.phonemeMappingsToolStripMenuItem.Name = "phonemeMappingsToolStripMenuItem";
-			this.phonemeMappingsToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
-			this.phonemeMappingsToolStripMenuItem.Text = "Edit Maps";
-			this.phonemeMappingsToolStripMenuItem.Click += new System.EventHandler(this.editMapsToolStripMenuItem_Click);
-			// 
-			// changeMapToolStripMenuItem
-			// 
-			this.changeMapToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.changeMapToolStripMenuItem.Name = "changeMapToolStripMenuItem";
-			this.changeMapToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
-			this.changeMapToolStripMenuItem.Text = "Change Element Map";
-			this.changeMapToolStripMenuItem.DropDownOpening += new System.EventHandler(this.changeMapToolStripMenuItem_DropDownOpening);
-			// 
-			// lyricConverterToolStripMenuItem
-			// 
-			this.lyricConverterToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.lyricConverterToolStripMenuItem.Name = "lyricConverterToolStripMenuItem";
-			this.lyricConverterToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
-			this.lyricConverterToolStripMenuItem.Text = "Lyric Converter";
-			this.lyricConverterToolStripMenuItem.Click += new System.EventHandler(this.textConverterToolStripMenuItem_Click);
-			// 
-			// papagayoImportToolStripMenuItem
-			// 
-			this.papagayoImportToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.papagayoImportToolStripMenuItem.Name = "papagayoImportToolStripMenuItem";
-			this.papagayoImportToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
-			this.papagayoImportToolStripMenuItem.Text = "Papagayo Import";
-			this.papagayoImportToolStripMenuItem.Click += new System.EventHandler(this.papagayoImportToolStripMenuItem_Click);
-			// 
-			// bulkEffectMoveToolStripMenuItem
-			// 
-			this.bulkEffectMoveToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.bulkEffectMoveToolStripMenuItem.Name = "bulkEffectMoveToolStripMenuItem";
-			this.bulkEffectMoveToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
-			this.bulkEffectMoveToolStripMenuItem.Text = "Bulk Effects Move";
-			this.bulkEffectMoveToolStripMenuItem.Click += new System.EventHandler(this.bulkEffectMoveToolStripMenuItem_Click);
-			// 
-			// helpDocumentationToolStripMenuItem
-			// 
-			this.helpDocumentationToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.helpDocumentationToolStripMenuItem.Name = "helpDocumentationToolStripMenuItem";
-			this.helpDocumentationToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
-			this.helpDocumentationToolStripMenuItem.Text = "Help";
-			this.helpDocumentationToolStripMenuItem.Click += new System.EventHandler(this.helpDocumentationToolStripMenuItem_Click);
-			// 
-			// timerPlaying
-			// 
-			this.timerPlaying.Interval = 40;
-			this.timerPlaying.Tick += new System.EventHandler(this.timerPlaying_Tick);
-			// 
-			// statusStrip
-			// 
-			this.statusStrip.AutoSize = false;
-			this.statusStrip.ImageScalingSize = new System.Drawing.Size(22, 22);
-			this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.lipSyncMappingsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.lipSyncMappingsToolStripMenuItem.Name = "lipSyncMappingsToolStripMenuItem";
+            this.lipSyncMappingsToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
+            this.lipSyncMappingsToolStripMenuItem.Text = "LipSync";
+            this.lipSyncMappingsToolStripMenuItem.DropDownOpening += new System.EventHandler(this.lipSyncMappingsToolStripMenuItem_DropDownOpening);
+            // 
+            // defaultMapToolStripMenuItem
+            // 
+            this.defaultMapToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.defaultMapToolStripMenuItem.Name = "defaultMapToolStripMenuItem";
+            this.defaultMapToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
+            this.defaultMapToolStripMenuItem.Text = "Default Map";
+            this.defaultMapToolStripMenuItem.DropDownOpening += new System.EventHandler(this.defaultMapToolStripMenuItem_DropDownOpening);
+            // 
+            // phonemeMappingsToolStripMenuItem
+            // 
+            this.phonemeMappingsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.phonemeMappingsToolStripMenuItem.Name = "phonemeMappingsToolStripMenuItem";
+            this.phonemeMappingsToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
+            this.phonemeMappingsToolStripMenuItem.Text = "Edit Maps";
+            this.phonemeMappingsToolStripMenuItem.Click += new System.EventHandler(this.editMapsToolStripMenuItem_Click);
+            // 
+            // changeMapToolStripMenuItem
+            // 
+            this.changeMapToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.changeMapToolStripMenuItem.Name = "changeMapToolStripMenuItem";
+            this.changeMapToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
+            this.changeMapToolStripMenuItem.Text = "Change Element Map";
+            this.changeMapToolStripMenuItem.DropDownOpening += new System.EventHandler(this.changeMapToolStripMenuItem_DropDownOpening);
+            // 
+            // lyricConverterToolStripMenuItem
+            // 
+            this.lyricConverterToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.lyricConverterToolStripMenuItem.Name = "lyricConverterToolStripMenuItem";
+            this.lyricConverterToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
+            this.lyricConverterToolStripMenuItem.Text = "Lyric Converter";
+            this.lyricConverterToolStripMenuItem.Click += new System.EventHandler(this.textConverterToolStripMenuItem_Click);
+            // 
+            // papagayoImportToolStripMenuItem
+            // 
+            this.papagayoImportToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.papagayoImportToolStripMenuItem.Name = "papagayoImportToolStripMenuItem";
+            this.papagayoImportToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
+            this.papagayoImportToolStripMenuItem.Text = "Papagayo Import";
+            this.papagayoImportToolStripMenuItem.Click += new System.EventHandler(this.papagayoImportToolStripMenuItem_Click);
+            // 
+            // bulkEffectMoveToolStripMenuItem
+            // 
+            this.bulkEffectMoveToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.bulkEffectMoveToolStripMenuItem.Name = "bulkEffectMoveToolStripMenuItem";
+            this.bulkEffectMoveToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
+            this.bulkEffectMoveToolStripMenuItem.Text = "Bulk Effects Move";
+            this.bulkEffectMoveToolStripMenuItem.Click += new System.EventHandler(this.bulkEffectMoveToolStripMenuItem_Click);
+            // 
+            // helpDocumentationToolStripMenuItem
+            // 
+            this.helpDocumentationToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.helpDocumentationToolStripMenuItem.Name = "helpDocumentationToolStripMenuItem";
+            this.helpDocumentationToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
+            this.helpDocumentationToolStripMenuItem.Text = "Help";
+            this.helpDocumentationToolStripMenuItem.Click += new System.EventHandler(this.helpDocumentationToolStripMenuItem_Click);
+            // 
+            // timerPlaying
+            // 
+            this.timerPlaying.Interval = 40;
+            this.timerPlaying.Tick += new System.EventHandler(this.timerPlaying_Tick);
+            // 
+            // statusStrip
+            // 
+            this.statusStrip.AutoSize = false;
+            this.statusStrip.ImageScalingSize = new System.Drawing.Size(22, 22);
+            this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripStatusLabel2,
             this.toolStripStatusLabel_currentTime,
             this.toolStripStatusLabel1,
@@ -1290,239 +1295,254 @@ namespace VixenModules.Editor.TimedSequenceEditor
             this.toolStripStatusLabel4,
             this.toolStripStatusLabel_RenderingElements,
             this.toolStripProgressBar_RenderingElements});
-			this.statusStrip.Location = new System.Drawing.Point(0, 590);
-			this.statusStrip.Name = "statusStrip";
-			this.statusStrip.Size = new System.Drawing.Size(1354, 19);
-			this.statusStrip.TabIndex = 4;
-			this.statusStrip.Text = "statusStrip1";
-			// 
-			// toolStripStatusLabel2
-			// 
-			this.toolStripStatusLabel2.AutoSize = false;
-			this.toolStripStatusLabel2.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripStatusLabel2.Margin = new System.Windows.Forms.Padding(0, 1, 0, 1);
-			this.toolStripStatusLabel2.Name = "toolStripStatusLabel2";
-			this.toolStripStatusLabel2.Size = new System.Drawing.Size(120, 17);
-			this.toolStripStatusLabel2.Text = "Current Position:";
-			this.toolStripStatusLabel2.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// toolStripStatusLabel_currentTime
-			// 
-			this.toolStripStatusLabel_currentTime.AutoSize = false;
-			this.toolStripStatusLabel_currentTime.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Right;
-			this.toolStripStatusLabel_currentTime.BorderStyle = System.Windows.Forms.Border3DStyle.Bump;
-			this.toolStripStatusLabel_currentTime.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripStatusLabel_currentTime.Margin = new System.Windows.Forms.Padding(0, 1, 0, 1);
-			this.toolStripStatusLabel_currentTime.Name = "toolStripStatusLabel_currentTime";
-			this.toolStripStatusLabel_currentTime.Size = new System.Drawing.Size(70, 17);
-			this.toolStripStatusLabel_currentTime.Text = "0:00.000";
-			this.toolStripStatusLabel_currentTime.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// toolStripStatusLabel1
-			// 
-			this.toolStripStatusLabel1.AutoSize = false;
-			this.toolStripStatusLabel1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripStatusLabel1.Margin = new System.Windows.Forms.Padding(0, 1, 0, 1);
-			this.toolStripStatusLabel1.Name = "toolStripStatusLabel1";
-			this.toolStripStatusLabel1.Size = new System.Drawing.Size(140, 17);
-			this.toolStripStatusLabel1.Text = "Sequence Length:";
-			this.toolStripStatusLabel1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// toolStripStatusLabel_sequenceLength
-			// 
-			this.toolStripStatusLabel_sequenceLength.AutoSize = false;
-			this.toolStripStatusLabel_sequenceLength.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Right;
-			this.toolStripStatusLabel_sequenceLength.BorderStyle = System.Windows.Forms.Border3DStyle.Bump;
-			this.toolStripStatusLabel_sequenceLength.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripStatusLabel_sequenceLength.Margin = new System.Windows.Forms.Padding(0, 1, 0, 1);
-			this.toolStripStatusLabel_sequenceLength.Name = "toolStripStatusLabel_sequenceLength";
-			this.toolStripStatusLabel_sequenceLength.Size = new System.Drawing.Size(70, 17);
-			this.toolStripStatusLabel_sequenceLength.Text = "0:00.000";
-			this.toolStripStatusLabel_sequenceLength.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// toolStripStatusLabel3
-			// 
-			this.toolStripStatusLabel3.AutoSize = false;
-			this.toolStripStatusLabel3.ForeColor = System.Drawing.Color.Red;
-			this.toolStripStatusLabel3.Margin = new System.Windows.Forms.Padding(0, 1, 0, 1);
-			this.toolStripStatusLabel3.Name = "toolStripStatusLabel3";
-			this.toolStripStatusLabel3.Size = new System.Drawing.Size(120, 17);
-			this.toolStripStatusLabel3.Text = "Play Delayed:";
-			this.toolStripStatusLabel3.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			this.toolStripStatusLabel3.Visible = false;
-			// 
-			// toolStripStatusLabel_delayPlay
-			// 
-			this.toolStripStatusLabel_delayPlay.AutoSize = false;
-			this.toolStripStatusLabel_delayPlay.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Right;
-			this.toolStripStatusLabel_delayPlay.BorderStyle = System.Windows.Forms.Border3DStyle.Bump;
-			this.toolStripStatusLabel_delayPlay.ForeColor = System.Drawing.Color.Red;
-			this.toolStripStatusLabel_delayPlay.Margin = new System.Windows.Forms.Padding(0, 1, 0, 1);
-			this.toolStripStatusLabel_delayPlay.Name = "toolStripStatusLabel_delayPlay";
-			this.toolStripStatusLabel_delayPlay.Size = new System.Drawing.Size(80, 17);
-			this.toolStripStatusLabel_delayPlay.Text = "00 Seconds";
-			this.toolStripStatusLabel_delayPlay.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			this.toolStripStatusLabel_delayPlay.Visible = false;
-			// 
-			// toolStripStatusLabel4
-			// 
-			this.toolStripStatusLabel4.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripStatusLabel4.Margin = new System.Windows.Forms.Padding(0, 1, 0, 1);
-			this.toolStripStatusLabel4.Name = "toolStripStatusLabel4";
-			this.toolStripStatusLabel4.Size = new System.Drawing.Size(939, 17);
-			this.toolStripStatusLabel4.Spring = true;
-			// 
-			// toolStripStatusLabel_RenderingElements
-			// 
-			this.toolStripStatusLabel_RenderingElements.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripStatusLabel_RenderingElements.Margin = new System.Windows.Forms.Padding(0, 1, 0, 1);
-			this.toolStripStatusLabel_RenderingElements.Name = "toolStripStatusLabel_RenderingElements";
-			this.toolStripStatusLabel_RenderingElements.Size = new System.Drawing.Size(115, 17);
-			this.toolStripStatusLabel_RenderingElements.Text = "Rendering Elements:";
-			this.toolStripStatusLabel_RenderingElements.Visible = false;
-			// 
-			// toolStripProgressBar_RenderingElements
-			// 
-			this.toolStripProgressBar_RenderingElements.Margin = new System.Windows.Forms.Padding(0, 1, 0, 1);
-			this.toolStripProgressBar_RenderingElements.Name = "toolStripProgressBar_RenderingElements";
-			this.toolStripProgressBar_RenderingElements.Size = new System.Drawing.Size(100, 17);
-			this.toolStripProgressBar_RenderingElements.Visible = false;
-			// 
-			// openFileDialog
-			// 
-			this.openFileDialog.Filter = "All files (*.*)|*.*";
-			// 
-			// toolStripContainer
-			// 
-			this.toolStripContainer.BottomToolStripPanelVisible = false;
-			// 
-			// toolStripContainer.ContentPanel
-			// 
-			this.toolStripContainer.ContentPanel.Controls.Add(this.dockPanel);
-			this.toolStripContainer.ContentPanel.Size = new System.Drawing.Size(1354, 539);
-			this.toolStripContainer.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.toolStripContainer.LeftToolStripPanelVisible = false;
-			this.toolStripContainer.Location = new System.Drawing.Point(0, 24);
-			this.toolStripContainer.Name = "toolStripContainer";
-			this.toolStripContainer.RightToolStripPanelVisible = false;
-			this.toolStripContainer.Size = new System.Drawing.Size(1354, 566);
-			this.toolStripContainer.TabIndex = 5;
-			this.toolStripContainer.Text = "toolStripContainer1";
-			// 
-			// toolStripContainer.TopToolStripPanel
-			// 
-			this.toolStripContainer.TopToolStripPanel.Controls.Add(this.toolStripOperations);
-			this.toolStripContainer.TopToolStripPanel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.toolStripContainer.TopToolStripPanel.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
-			// 
-			// dockPanel
-			// 
-			this.dockPanel.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(80)))), ((int)(((byte)(80)))), ((int)(((byte)(80)))));
-			this.dockPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.dockPanel.DockBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(80)))), ((int)(((byte)(80)))), ((int)(((byte)(80)))));
-			this.dockPanel.DockLeftPortion = 200D;
-			this.dockPanel.DocumentStyle = WeifenLuo.WinFormsUI.Docking.DocumentStyle.DockingWindow;
-			this.dockPanel.Location = new System.Drawing.Point(0, 0);
-			this.dockPanel.Name = "dockPanel";
-			this.dockPanel.Size = new System.Drawing.Size(1354, 539);
-			dockPanelGradient1.EndColor = System.Drawing.SystemColors.ControlLight;
-			dockPanelGradient1.StartColor = System.Drawing.SystemColors.ControlLight;
-			autoHideStripSkin1.DockStripGradient = dockPanelGradient1;
-			tabGradient1.EndColor = System.Drawing.SystemColors.Control;
-			tabGradient1.StartColor = System.Drawing.SystemColors.Control;
-			tabGradient1.TextColor = System.Drawing.SystemColors.ControlDarkDark;
-			autoHideStripSkin1.TabGradient = tabGradient1;
-			autoHideStripSkin1.TextFont = new System.Drawing.Font("Segoe UI", 9F);
-			dockPanelSkin1.AutoHideStripSkin = autoHideStripSkin1;
-			tabGradient2.EndColor = System.Drawing.SystemColors.ControlLightLight;
-			tabGradient2.StartColor = System.Drawing.SystemColors.ControlLightLight;
-			tabGradient2.TextColor = System.Drawing.SystemColors.ControlText;
-			dockPaneStripGradient1.ActiveTabGradient = tabGradient2;
-			dockPanelGradient2.EndColor = System.Drawing.SystemColors.Control;
-			dockPanelGradient2.StartColor = System.Drawing.SystemColors.Control;
-			dockPaneStripGradient1.DockStripGradient = dockPanelGradient2;
-			tabGradient3.EndColor = System.Drawing.SystemColors.ControlLight;
-			tabGradient3.StartColor = System.Drawing.SystemColors.ControlLight;
-			tabGradient3.TextColor = System.Drawing.SystemColors.ControlText;
-			dockPaneStripGradient1.InactiveTabGradient = tabGradient3;
-			dockPaneStripSkin1.DocumentGradient = dockPaneStripGradient1;
-			dockPaneStripSkin1.TextFont = new System.Drawing.Font("Segoe UI", 9F);
-			tabGradient4.EndColor = System.Drawing.SystemColors.ActiveCaption;
-			tabGradient4.LinearGradientMode = System.Drawing.Drawing2D.LinearGradientMode.Vertical;
-			tabGradient4.StartColor = System.Drawing.SystemColors.GradientActiveCaption;
-			tabGradient4.TextColor = System.Drawing.SystemColors.ActiveCaptionText;
-			dockPaneStripToolWindowGradient1.ActiveCaptionGradient = tabGradient4;
-			tabGradient5.EndColor = System.Drawing.SystemColors.Control;
-			tabGradient5.StartColor = System.Drawing.SystemColors.Control;
-			tabGradient5.TextColor = System.Drawing.SystemColors.ControlText;
-			dockPaneStripToolWindowGradient1.ActiveTabGradient = tabGradient5;
-			dockPanelGradient3.EndColor = System.Drawing.SystemColors.ControlLight;
-			dockPanelGradient3.StartColor = System.Drawing.SystemColors.ControlLight;
-			dockPaneStripToolWindowGradient1.DockStripGradient = dockPanelGradient3;
-			tabGradient6.EndColor = System.Drawing.SystemColors.InactiveCaption;
-			tabGradient6.LinearGradientMode = System.Drawing.Drawing2D.LinearGradientMode.Vertical;
-			tabGradient6.StartColor = System.Drawing.SystemColors.GradientInactiveCaption;
-			tabGradient6.TextColor = System.Drawing.SystemColors.InactiveCaptionText;
-			dockPaneStripToolWindowGradient1.InactiveCaptionGradient = tabGradient6;
-			tabGradient7.EndColor = System.Drawing.Color.Transparent;
-			tabGradient7.StartColor = System.Drawing.Color.Transparent;
-			tabGradient7.TextColor = System.Drawing.SystemColors.ControlDarkDark;
-			dockPaneStripToolWindowGradient1.InactiveTabGradient = tabGradient7;
-			dockPaneStripSkin1.ToolWindowGradient = dockPaneStripToolWindowGradient1;
-			dockPanelSkin1.DockPaneStripSkin = dockPaneStripSkin1;
-			this.dockPanel.Skin = dockPanelSkin1;
-			this.dockPanel.TabIndex = 13;
-			// 
-			// saveFileDialog
-			// 
-			this.saveFileDialog.Title = "Save timed sequence";
-			// 
-			// contextMenuStripElementSelection
-			// 
-			this.contextMenuStripElementSelection.ImageScalingSize = new System.Drawing.Size(24, 24);
-			this.contextMenuStripElementSelection.Name = "contextMenuStripElementSelection";
-			this.contextMenuStripElementSelection.Size = new System.Drawing.Size(61, 4);
-			// 
-			// timerPostponePlay
-			// 
-			this.timerPostponePlay.Tick += new System.EventHandler(this.timerPostponePlay_Tick);
-			// 
-			// timerDelayCountdown
-			// 
-			this.timerDelayCountdown.Interval = 1000;
-			this.timerDelayCountdown.Tick += new System.EventHandler(this.timerDelayCountdown_Tick);
-			// 
-			// TimedSequenceEditorForm
-			// 
-			this.AllowDrop = true;
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(80)))), ((int)(((byte)(80)))), ((int)(((byte)(80)))));
-			this.ClientSize = new System.Drawing.Size(1354, 609);
-			this.Controls.Add(this.toolStripContainer);
-			this.Controls.Add(this.statusStrip);
-			this.Controls.Add(this.menuStrip);
-			this.DoubleBuffered = true;
-			this.KeyPreview = true;
-			this.MainMenuStrip = this.menuStrip;
-			this.Name = "TimedSequenceEditorForm";
-			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Timed Sequence Editor";
-			this.Load += new System.EventHandler(this.TimedSequenceEditorForm_Load);
-			this.Shown += new System.EventHandler(this.TimedSequenceEditorForm_Shown);
-			this.toolStripOperations.ResumeLayout(false);
-			this.toolStripOperations.PerformLayout();
-			this.menuStrip.ResumeLayout(false);
-			this.menuStrip.PerformLayout();
-			this.statusStrip.ResumeLayout(false);
-			this.statusStrip.PerformLayout();
-			this.toolStripContainer.ContentPanel.ResumeLayout(false);
-			this.toolStripContainer.TopToolStripPanel.ResumeLayout(false);
-			this.toolStripContainer.TopToolStripPanel.PerformLayout();
-			this.toolStripContainer.ResumeLayout(false);
-			this.toolStripContainer.PerformLayout();
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.statusStrip.Location = new System.Drawing.Point(0, 681);
+            this.statusStrip.Name = "statusStrip";
+            this.statusStrip.Padding = new System.Windows.Forms.Padding(1, 0, 16, 0);
+            this.statusStrip.Size = new System.Drawing.Size(1580, 22);
+            this.statusStrip.TabIndex = 4;
+            this.statusStrip.Text = "statusStrip1";
+            // 
+            // toolStripStatusLabel2
+            // 
+            this.toolStripStatusLabel2.AutoSize = false;
+            this.toolStripStatusLabel2.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripStatusLabel2.Margin = new System.Windows.Forms.Padding(0, 1, 0, 1);
+            this.toolStripStatusLabel2.Name = "toolStripStatusLabel2";
+            this.toolStripStatusLabel2.Size = new System.Drawing.Size(120, 20);
+            this.toolStripStatusLabel2.Text = "Current Position:";
+            this.toolStripStatusLabel2.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // toolStripStatusLabel_currentTime
+            // 
+            this.toolStripStatusLabel_currentTime.AutoSize = false;
+            this.toolStripStatusLabel_currentTime.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Right;
+            this.toolStripStatusLabel_currentTime.BorderStyle = System.Windows.Forms.Border3DStyle.Bump;
+            this.toolStripStatusLabel_currentTime.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripStatusLabel_currentTime.Margin = new System.Windows.Forms.Padding(0, 1, 0, 1);
+            this.toolStripStatusLabel_currentTime.Name = "toolStripStatusLabel_currentTime";
+            this.toolStripStatusLabel_currentTime.Size = new System.Drawing.Size(70, 20);
+            this.toolStripStatusLabel_currentTime.Text = "0:00.000";
+            this.toolStripStatusLabel_currentTime.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // toolStripStatusLabel1
+            // 
+            this.toolStripStatusLabel1.AutoSize = false;
+            this.toolStripStatusLabel1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripStatusLabel1.Margin = new System.Windows.Forms.Padding(0, 1, 0, 1);
+            this.toolStripStatusLabel1.Name = "toolStripStatusLabel1";
+            this.toolStripStatusLabel1.Size = new System.Drawing.Size(140, 20);
+            this.toolStripStatusLabel1.Text = "Sequence Length:";
+            this.toolStripStatusLabel1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // toolStripStatusLabel_sequenceLength
+            // 
+            this.toolStripStatusLabel_sequenceLength.AutoSize = false;
+            this.toolStripStatusLabel_sequenceLength.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Right;
+            this.toolStripStatusLabel_sequenceLength.BorderStyle = System.Windows.Forms.Border3DStyle.Bump;
+            this.toolStripStatusLabel_sequenceLength.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripStatusLabel_sequenceLength.Margin = new System.Windows.Forms.Padding(0, 1, 0, 1);
+            this.toolStripStatusLabel_sequenceLength.Name = "toolStripStatusLabel_sequenceLength";
+            this.toolStripStatusLabel_sequenceLength.Size = new System.Drawing.Size(70, 20);
+            this.toolStripStatusLabel_sequenceLength.Text = "0:00.000";
+            this.toolStripStatusLabel_sequenceLength.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // toolStripStatusLabel3
+            // 
+            this.toolStripStatusLabel3.AutoSize = false;
+            this.toolStripStatusLabel3.ForeColor = System.Drawing.Color.Red;
+            this.toolStripStatusLabel3.Margin = new System.Windows.Forms.Padding(0, 1, 0, 1);
+            this.toolStripStatusLabel3.Name = "toolStripStatusLabel3";
+            this.toolStripStatusLabel3.Size = new System.Drawing.Size(120, 20);
+            this.toolStripStatusLabel3.Text = "Play Delayed:";
+            this.toolStripStatusLabel3.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.toolStripStatusLabel3.Visible = false;
+            // 
+            // toolStripStatusLabel_delayPlay
+            // 
+            this.toolStripStatusLabel_delayPlay.AutoSize = false;
+            this.toolStripStatusLabel_delayPlay.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Right;
+            this.toolStripStatusLabel_delayPlay.BorderStyle = System.Windows.Forms.Border3DStyle.Bump;
+            this.toolStripStatusLabel_delayPlay.ForeColor = System.Drawing.Color.Red;
+            this.toolStripStatusLabel_delayPlay.Margin = new System.Windows.Forms.Padding(0, 1, 0, 1);
+            this.toolStripStatusLabel_delayPlay.Name = "toolStripStatusLabel_delayPlay";
+            this.toolStripStatusLabel_delayPlay.Size = new System.Drawing.Size(80, 20);
+            this.toolStripStatusLabel_delayPlay.Text = "00 Seconds";
+            this.toolStripStatusLabel_delayPlay.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.toolStripStatusLabel_delayPlay.Visible = false;
+            // 
+            // toolStripStatusLabel4
+            // 
+            this.toolStripStatusLabel4.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripStatusLabel4.Margin = new System.Windows.Forms.Padding(0, 1, 0, 1);
+            this.toolStripStatusLabel4.Name = "toolStripStatusLabel4";
+            this.toolStripStatusLabel4.Size = new System.Drawing.Size(1163, 20);
+            this.toolStripStatusLabel4.Spring = true;
+            // 
+            // toolStripStatusLabel_RenderingElements
+            // 
+            this.toolStripStatusLabel_RenderingElements.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripStatusLabel_RenderingElements.Margin = new System.Windows.Forms.Padding(0, 1, 0, 1);
+            this.toolStripStatusLabel_RenderingElements.Name = "toolStripStatusLabel_RenderingElements";
+            this.toolStripStatusLabel_RenderingElements.Size = new System.Drawing.Size(115, 20);
+            this.toolStripStatusLabel_RenderingElements.Text = "Rendering Elements:";
+            this.toolStripStatusLabel_RenderingElements.Visible = false;
+            // 
+            // toolStripProgressBar_RenderingElements
+            // 
+            this.toolStripProgressBar_RenderingElements.Margin = new System.Windows.Forms.Padding(0, 1, 0, 1);
+            this.toolStripProgressBar_RenderingElements.Name = "toolStripProgressBar_RenderingElements";
+            this.toolStripProgressBar_RenderingElements.Size = new System.Drawing.Size(117, 20);
+            this.toolStripProgressBar_RenderingElements.Visible = false;
+            // 
+            // openFileDialog
+            // 
+            this.openFileDialog.Filter = "All files (*.*)|*.*";
+            // 
+            // toolStripContainer
+            // 
+            this.toolStripContainer.BottomToolStripPanelVisible = false;
+            // 
+            // toolStripContainer.ContentPanel
+            // 
+            this.toolStripContainer.ContentPanel.Controls.Add(this.dockPanel);
+            this.toolStripContainer.ContentPanel.Size = new System.Drawing.Size(1580, 630);
+            this.toolStripContainer.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.toolStripContainer.LeftToolStripPanelVisible = false;
+            this.toolStripContainer.Location = new System.Drawing.Point(0, 24);
+            this.toolStripContainer.Name = "toolStripContainer";
+            this.toolStripContainer.RightToolStripPanelVisible = false;
+            this.toolStripContainer.Size = new System.Drawing.Size(1580, 657);
+            this.toolStripContainer.TabIndex = 5;
+            this.toolStripContainer.Text = "toolStripContainer1";
+            // 
+            // toolStripContainer.TopToolStripPanel
+            // 
+            this.toolStripContainer.TopToolStripPanel.Controls.Add(this.toolStripOperations);
+            this.toolStripContainer.TopToolStripPanel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
+            this.toolStripContainer.TopToolStripPanel.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
+            // 
+            // dockPanel
+            // 
+            this.dockPanel.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(80)))), ((int)(((byte)(80)))), ((int)(((byte)(80)))));
+            this.dockPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.dockPanel.DockBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(80)))), ((int)(((byte)(80)))), ((int)(((byte)(80)))));
+            this.dockPanel.DockLeftPortion = 200D;
+            this.dockPanel.DocumentStyle = WeifenLuo.WinFormsUI.Docking.DocumentStyle.DockingWindow;
+            this.dockPanel.Location = new System.Drawing.Point(0, 0);
+            this.dockPanel.Name = "dockPanel";
+            this.dockPanel.Size = new System.Drawing.Size(1580, 630);
+            dockPanelGradient7.EndColor = System.Drawing.SystemColors.ControlLight;
+            dockPanelGradient7.StartColor = System.Drawing.SystemColors.ControlLight;
+            autoHideStripSkin3.DockStripGradient = dockPanelGradient7;
+            tabGradient15.EndColor = System.Drawing.SystemColors.Control;
+            tabGradient15.StartColor = System.Drawing.SystemColors.Control;
+            tabGradient15.TextColor = System.Drawing.SystemColors.ControlDarkDark;
+            autoHideStripSkin3.TabGradient = tabGradient15;
+            autoHideStripSkin3.TextFont = new System.Drawing.Font("Segoe UI", 9F);
+            dockPanelSkin3.AutoHideStripSkin = autoHideStripSkin3;
+            tabGradient16.EndColor = System.Drawing.SystemColors.ControlLightLight;
+            tabGradient16.StartColor = System.Drawing.SystemColors.ControlLightLight;
+            tabGradient16.TextColor = System.Drawing.SystemColors.ControlText;
+            dockPaneStripGradient3.ActiveTabGradient = tabGradient16;
+            dockPanelGradient8.EndColor = System.Drawing.SystemColors.Control;
+            dockPanelGradient8.StartColor = System.Drawing.SystemColors.Control;
+            dockPaneStripGradient3.DockStripGradient = dockPanelGradient8;
+            tabGradient17.EndColor = System.Drawing.SystemColors.ControlLight;
+            tabGradient17.StartColor = System.Drawing.SystemColors.ControlLight;
+            tabGradient17.TextColor = System.Drawing.SystemColors.ControlText;
+            dockPaneStripGradient3.InactiveTabGradient = tabGradient17;
+            dockPaneStripSkin3.DocumentGradient = dockPaneStripGradient3;
+            dockPaneStripSkin3.TextFont = new System.Drawing.Font("Segoe UI", 9F);
+            tabGradient18.EndColor = System.Drawing.SystemColors.ActiveCaption;
+            tabGradient18.LinearGradientMode = System.Drawing.Drawing2D.LinearGradientMode.Vertical;
+            tabGradient18.StartColor = System.Drawing.SystemColors.GradientActiveCaption;
+            tabGradient18.TextColor = System.Drawing.SystemColors.ActiveCaptionText;
+            dockPaneStripToolWindowGradient3.ActiveCaptionGradient = tabGradient18;
+            tabGradient19.EndColor = System.Drawing.SystemColors.Control;
+            tabGradient19.StartColor = System.Drawing.SystemColors.Control;
+            tabGradient19.TextColor = System.Drawing.SystemColors.ControlText;
+            dockPaneStripToolWindowGradient3.ActiveTabGradient = tabGradient19;
+            dockPanelGradient9.EndColor = System.Drawing.SystemColors.ControlLight;
+            dockPanelGradient9.StartColor = System.Drawing.SystemColors.ControlLight;
+            dockPaneStripToolWindowGradient3.DockStripGradient = dockPanelGradient9;
+            tabGradient20.EndColor = System.Drawing.SystemColors.InactiveCaption;
+            tabGradient20.LinearGradientMode = System.Drawing.Drawing2D.LinearGradientMode.Vertical;
+            tabGradient20.StartColor = System.Drawing.SystemColors.GradientInactiveCaption;
+            tabGradient20.TextColor = System.Drawing.SystemColors.InactiveCaptionText;
+            dockPaneStripToolWindowGradient3.InactiveCaptionGradient = tabGradient20;
+            tabGradient21.EndColor = System.Drawing.Color.Transparent;
+            tabGradient21.StartColor = System.Drawing.Color.Transparent;
+            tabGradient21.TextColor = System.Drawing.SystemColors.ControlDarkDark;
+            dockPaneStripToolWindowGradient3.InactiveTabGradient = tabGradient21;
+            dockPaneStripSkin3.ToolWindowGradient = dockPaneStripToolWindowGradient3;
+            dockPanelSkin3.DockPaneStripSkin = dockPaneStripSkin3;
+            this.dockPanel.Skin = dockPanelSkin3;
+            this.dockPanel.TabIndex = 13;
+            // 
+            // saveFileDialog
+            // 
+            this.saveFileDialog.Title = "Save timed sequence";
+            // 
+            // contextMenuStripElementSelection
+            // 
+            this.contextMenuStripElementSelection.ImageScalingSize = new System.Drawing.Size(24, 24);
+            this.contextMenuStripElementSelection.Name = "contextMenuStripElementSelection";
+            this.contextMenuStripElementSelection.Size = new System.Drawing.Size(61, 4);
+            // 
+            // timerPostponePlay
+            // 
+            this.timerPostponePlay.Tick += new System.EventHandler(this.timerPostponePlay_Tick);
+            // 
+            // timerDelayCountdown
+            // 
+            this.timerDelayCountdown.Interval = 1000;
+            this.timerDelayCountdown.Tick += new System.EventHandler(this.timerDelayCountdown_Tick);
+            // 
+            // toolStripMenuItem_expandAllRows
+            // 
+            this.toolStripMenuItem_expandAllRows.Name = "toolStripMenuItem_expandAllRows";
+            this.toolStripMenuItem_expandAllRows.Size = new System.Drawing.Size(234, 22);
+            this.toolStripMenuItem_expandAllRows.Text = "Expand All Rows";
+            this.toolStripMenuItem_expandAllRows.Click += new System.EventHandler(this.toolStripMenuItem_expandAllRows_Click);
+            // 
+            // toolStripMenuItem_contractAllRows
+            // 
+            this.toolStripMenuItem_contractAllRows.Name = "toolStripMenuItem_contractAllRows";
+            this.toolStripMenuItem_contractAllRows.Size = new System.Drawing.Size(234, 22);
+            this.toolStripMenuItem_contractAllRows.Text = "Contract All Rows";
+            this.toolStripMenuItem_contractAllRows.Click += new System.EventHandler(this.toolStripMenuItem_contractAllRows_Click);
+            // 
+            // TimedSequenceEditorForm
+            // 
+            this.AllowDrop = true;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(80)))), ((int)(((byte)(80)))), ((int)(((byte)(80)))));
+            this.ClientSize = new System.Drawing.Size(1580, 703);
+            this.Controls.Add(this.toolStripContainer);
+            this.Controls.Add(this.statusStrip);
+            this.Controls.Add(this.menuStrip);
+            this.DoubleBuffered = true;
+            this.KeyPreview = true;
+            this.MainMenuStrip = this.menuStrip;
+            this.Name = "TimedSequenceEditorForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Timed Sequence Editor";
+            this.Load += new System.EventHandler(this.TimedSequenceEditorForm_Load);
+            this.Shown += new System.EventHandler(this.TimedSequenceEditorForm_Shown);
+            this.toolStripOperations.ResumeLayout(false);
+            this.toolStripOperations.PerformLayout();
+            this.menuStrip.ResumeLayout(false);
+            this.menuStrip.PerformLayout();
+            this.statusStrip.ResumeLayout(false);
+            this.statusStrip.PerformLayout();
+            this.toolStripContainer.ContentPanel.ResumeLayout(false);
+            this.toolStripContainer.TopToolStripPanel.ResumeLayout(false);
+            this.toolStripContainer.TopToolStripPanel.PerformLayout();
+            this.toolStripContainer.ResumeLayout(false);
+            this.toolStripContainer.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 
@@ -1663,5 +1683,7 @@ namespace VixenModules.Editor.TimedSequenceEditor
 		private System.Windows.Forms.ToolStripMenuItem undoToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem redoToolStripMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator8;
-	}
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem_expandAllRows;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem_contractAllRows;
+    }
 }

--- a/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
+++ b/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
@@ -91,7 +91,13 @@ namespace VixenModules.Editor.TimedSequenceEditor
 		private TimeSpan? _mPrevPlaybackStart;
 		private TimeSpan? _mPrevPlaybackEnd;
 
-		private bool _mModified;
+        //List containing the rows to expand automatically when loading
+        List<Guid> _expandedRows = new List<Guid>();
+
+        //Default height to set the rows when opening
+        int _defaultRowHeight = 0;
+
+        private bool _mModified;
 
 		private float _timingSpeed = 1;
 
@@ -336,16 +342,16 @@ namespace VixenModules.Editor.TimedSequenceEditor
 				Size = new Size(desktopBounds.Width, desktopBounds.Height);
 			}
 
+            _defaultRowHeight = xml.GetSetting(XMLProfileSettings.SettingType.AppSettings, string.Format("{0}/DefaultRowHeight", Name), 0);
 
             _expandedRows.Clear();
 
-            int expandedRowsCount = xml.GetSetting(XMLProfileSettings.SettingType.Profiles, string.Format("{0}/ExpandedRowsCount", Name), 0);
+            int expandedRowsCount = xml.GetSetting(XMLProfileSettings.SettingType.AppSettings, string.Format("{0}/ExpandedRowsCount", Name), 0);
 
-            xml.PutSetting(XMLProfileSettings.SettingType.Profiles, string.Format("{0}/ExpandedRowsCount", Name), _expandedRows.Count);
-
+            
             for (int i = 0; i < expandedRowsCount; i++)
             {
-                string id = xml.GetSetting(XMLProfileSettings.SettingType.Profiles, string.Format("{0}/ExpandedRows{1}", Name, i), "");
+                string id = xml.GetSetting(XMLProfileSettings.SettingType.AppSettings, string.Format("{0}/ExpandedRows{1}", Name, i), "");
 
                 if(string.IsNullOrEmpty(id)==false)
                 {
@@ -3312,7 +3318,7 @@ namespace VixenModules.Editor.TimedSequenceEditor
 
 
 		private int _doEventsCounter;
-        List<Guid> _expandedRows = new List<Guid>();
+        
 
 		/// <summary>
 		/// Adds a single given element node as a row in the timeline control. Recursively adds all
@@ -3330,6 +3336,9 @@ namespace VixenModules.Editor.TimedSequenceEditor
 
             if (_expandedRows.Contains(node.Id) )
                 newRow.TreeOpen = true;
+
+            if (_defaultRowHeight != 0)
+                newRow.Height = _defaultRowHeight;
 
 			// Tag it with the node it refers to, and take note of which row the given element node will refer to.
 			newRow.Tag = node;
@@ -4864,6 +4873,9 @@ namespace VixenModules.Editor.TimedSequenceEditor
 			xml.PutSetting(XMLProfileSettings.SettingType.AppSettings, string.Format("{0}/ToolPaletteLinkCurves", Name), ToolsForm.LinkCurves);
 			xml.PutSetting(XMLProfileSettings.SettingType.AppSettings, string.Format("{0}/ToolPaletteLinkGradients", Name), ToolsForm.LinkGradients);
 
+            if(TimelineControl.Rows.Count() > 0)
+                xml.PutSetting(XMLProfileSettings.SettingType.AppSettings, string.Format("{0}/DefaultRowHeight", Name), TimelineControl.Rows.ElementAt(0).Height);
+
             //Save the expanded 
             _expandedRows.Clear();
             foreach (var row in TimelineControl.Rows)
@@ -4872,11 +4884,11 @@ namespace VixenModules.Editor.TimedSequenceEditor
                     _expandedRows.Add(((ElementNode)row.Tag).Id);
             }
 
-            xml.PutSetting(XMLProfileSettings.SettingType.Profiles, string.Format("{0}/ExpandedRowsCount", Name), _expandedRows.Count);
+            xml.PutSetting(XMLProfileSettings.SettingType.AppSettings, string.Format("{0}/ExpandedRowsCount", Name), _expandedRows.Count);
 
             for (int i = 0; i < _expandedRows.Count; i++)
             {
-                xml.PutSetting(XMLProfileSettings.SettingType.Profiles, string.Format("{0}/ExpandedRows{1}", Name, i), _expandedRows[i].ToString());
+                xml.PutSetting(XMLProfileSettings.SettingType.AppSettings, string.Format("{0}/ExpandedRows{1}", Name, i), _expandedRows[i].ToString());
             }
 
             //This .Close is here because we need to save some of the settings from the form before it is closed.

--- a/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
+++ b/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
@@ -336,7 +336,25 @@ namespace VixenModules.Editor.TimedSequenceEditor
 				Size = new Size(desktopBounds.Width, desktopBounds.Height);
 			}
 
-			_effectNodeToElement = new Dictionary<EffectNode, Element>();
+
+            _expandedRows.Clear();
+
+            int expandedRowsCount = xml.GetSetting(XMLProfileSettings.SettingType.Profiles, string.Format("{0}/ExpandedRowsCount", Name), 0);
+
+            xml.PutSetting(XMLProfileSettings.SettingType.Profiles, string.Format("{0}/ExpandedRowsCount", Name), _expandedRows.Count);
+
+            for (int i = 0; i < expandedRowsCount; i++)
+            {
+                string id = xml.GetSetting(XMLProfileSettings.SettingType.Profiles, string.Format("{0}/ExpandedRows{1}", Name, i), "");
+
+                if(string.IsNullOrEmpty(id)==false)
+                {
+                    _expandedRows.Add(new Guid(id));
+                }
+            }
+
+
+            _effectNodeToElement = new Dictionary<EffectNode, Element>();
 			_elementNodeToRows = new Dictionary<ElementNode, List<Row>>();
 
 			TimelineControl.grid.RenderProgressChanged += OnRenderProgressChanged;
@@ -392,11 +410,6 @@ namespace VixenModules.Editor.TimedSequenceEditor
 			_library = ApplicationServices.Get<IAppModuleInstance>(LipSyncMapDescriptor.ModuleID) as LipSyncMapLibrary;
 			Cursor.Current = Cursors.Default;
 
-#if DEBUG
-			ToolStripButton b = new ToolStripButton("[Debug Break]");
-			b.Click += b_Click;
-			toolStripOperations.Items.Add(b);
-#endif
 		}
 
 		private void SetDockDefaults()
@@ -3299,6 +3312,7 @@ namespace VixenModules.Editor.TimedSequenceEditor
 
 
 		private int _doEventsCounter;
+        List<Guid> _expandedRows = new List<Guid>();
 
 		/// <summary>
 		/// Adds a single given element node as a row in the timeline control. Recursively adds all
@@ -3313,6 +3327,9 @@ namespace VixenModules.Editor.TimedSequenceEditor
 			Row newRow = TimelineControl.AddRow(label, parentRow, 32);
 			newRow.ElementRemoved += ElementRemovedFromRowHandler;
 			newRow.ElementAdded += ElementAddedToRowHandler;
+
+            if (_expandedRows.Contains(node.Id) )
+                newRow.TreeOpen = true;
 
 			// Tag it with the node it refers to, and take note of which row the given element node will refer to.
 			newRow.Tag = node;
@@ -4847,8 +4864,23 @@ namespace VixenModules.Editor.TimedSequenceEditor
 			xml.PutSetting(XMLProfileSettings.SettingType.AppSettings, string.Format("{0}/ToolPaletteLinkCurves", Name), ToolsForm.LinkCurves);
 			xml.PutSetting(XMLProfileSettings.SettingType.AppSettings, string.Format("{0}/ToolPaletteLinkGradients", Name), ToolsForm.LinkGradients);
 
-			//This .Close is here because we need to save some of the settings from the form before it is closed.
-			ToolsForm.Close();
+            //Save the expanded 
+            _expandedRows.Clear();
+            foreach (var row in TimelineControl.Rows)
+            {
+                if(row.TreeOpen == true)
+                    _expandedRows.Add(((ElementNode)row.Tag).Id);
+            }
+
+            xml.PutSetting(XMLProfileSettings.SettingType.Profiles, string.Format("{0}/ExpandedRowsCount", Name), _expandedRows.Count);
+
+            for (int i = 0; i < _expandedRows.Count; i++)
+            {
+                xml.PutSetting(XMLProfileSettings.SettingType.Profiles, string.Format("{0}/ExpandedRows{1}", Name, i), _expandedRows[i].ToString());
+            }
+
+            //This .Close is here because we need to save some of the settings from the form before it is closed.
+            ToolsForm.Close();
 
 			//These are only saved in options
 			//xml.PutPreference(string.Format("{0}/AutoSaveInterval", Name), _autoSaveTimer.Interval);
@@ -5515,9 +5547,25 @@ namespace VixenModules.Editor.TimedSequenceEditor
 			}
 		}
 
-	}
+        private void toolStripMenuItem_expandAllRows_Click(object sender, EventArgs e)
+        {
+            foreach(var row in TimelineControl.Rows)
+            {
+                if(row.ParentDepth == 0)
+                    row.TreeOpen = true;
+            }
+        }
 
-	[Serializable]
+        private void toolStripMenuItem_contractAllRows_Click(object sender, EventArgs e)
+        {
+            foreach (var row in TimelineControl.Rows)
+            {
+                row.TreeOpen = false;
+            }
+        }
+    }
+
+    [Serializable]
 	internal class TimelineElementsClipboardData
 	{
 		public TimelineElementsClipboardData()


### PR DESCRIPTION
Fixes http://bugs.vixenlights.com/browse/VIX-913.

It also save the rows that are expanded and restores them when reopening the window

Description from the bug tracker:
I would like to ask for some method to set the row sizes within the editor. Currently you can Ctrl-Shift- "-" (without the quotes) to zoom the rows out. I want to see many more rows on the screen than what is the default now. Every time I enter a sequence, the first thing I do is to use this key-combination to get more rows on the screen.

It would be wonderful if the program allowed this to be set as a "personal preference" where the sizing would come up as the default.
