### PR TITLE
Adding bi-directional wipe

### DIFF
--- a/Modules/Effect/Wipe/WipeDirection.cs
+++ b/Modules/Effect/Wipe/WipeDirection.cs
@@ -15,6 +15,8 @@ namespace VixenModules.Effect.Wipe {
 		[Description("Burst In")]
 		In = 4,
 		[Description("Burst Out")]
-		Out = 5
+		Out = 5,
+        [Description("Wipe Left, Wipe Right")]
+        LeftRight = 6
 	}
 }

--- a/Modules/Effect/Wipe/WipeModule.cs
+++ b/Modules/Effect/Wipe/WipeModule.cs
@@ -193,7 +193,72 @@ namespace VixenModules.Effect.Wipe
 				case WipeDirection.In:
 					RenderBurst(tokenSource, _data.Direction);
 					break;
-			}
+                case WipeDirection.LeftRight:
+                    renderNodes =  TargetNodes.SelectMany(x => x.GetLeafEnumerator())
+                        .OrderByDescending(x =>
+                        {
+                            var prop = x.Properties.Get(LocationDescriptor._typeId);
+                            if (prop != null)
+                            {
+                                return ((LocationData)prop.ModuleData).X;
+                            }
+                            return 1;
+                        })
+                        .ThenBy(x =>
+                        {
+                            var prop = x.Properties.Get(LocationDescriptor._typeId);
+                            if (prop != null)
+                            {
+                                return ((LocationData)prop.ModuleData).Y;
+                            }
+                            return 1;
+                        })
+                        .GroupBy(x =>
+                        {
+                            var prop = x.Properties.Get(LocationDescriptor._typeId);
+                            if (prop != null)
+                            {
+                                return ((LocationData)prop.ModuleData).X;
+                            }
+                            return 1;
+                        })
+                        .Distinct();
+                    RenderNonBurst(tokenSource, renderNodes);
+
+                    renderNodes = TargetNodes.SelectMany(x => x.GetLeafEnumerator())
+                    .OrderBy(x =>
+                    {
+                        var prop = x.Properties.Get(LocationDescriptor._typeId);
+                        if (prop != null)
+                        {
+                            return ((LocationData)prop.ModuleData).X;
+                        }
+                        return 1;
+                    })
+                    .ThenBy(x =>
+                    {
+                        var prop = x.Properties.Get(LocationDescriptor._typeId);
+                        if (prop != null)
+                        {
+                            return ((LocationData)prop.ModuleData).Y;
+                        }
+                        return 1;
+                    })
+                    .GroupBy(x =>
+                    {
+                        var prop = x.Properties.Get(LocationDescriptor._typeId);
+                        if (prop != null)
+                        {
+                            return ((LocationData)prop.ModuleData).X;
+                        }
+                        return 1;
+                    })
+                    .Distinct();
+
+
+                    RenderNonBurst(tokenSource, renderNodes);
+                    break;
+            }
 		}
 
 		private void RenderNonBurst(CancellationTokenSource tokenSource, IEnumerable<IGrouping<int, ElementNode>> renderNodes)


### PR DESCRIPTION
- Adding new wipe direction enumeration "Wipe Left, Wipe Right" as the
basis for a bi directional left/right wipe.
- Adding new case in VixenModules.Effect.Wipe.RenderNodes to support the
new bidirectional wipe