### PR TITLE
VIX-1957 - Schedules that span midnight not stopping

### DIFF
--- a/Modules/App/SuperScheduler/ScheduleItem.cs
+++ b/Modules/App/SuperScheduler/ScheduleItem.cs
@@ -143,7 +143,7 @@ namespace VixenModules.App.SuperScheduler
 
 				if (result < StartTime)
 				{
-					result = _endTime.AddDays(1);
+					result = result.AddDays(1);
 				}
 				return result;
 			}


### PR DESCRIPTION
This fixed a bug where schedules that span midnight may not stop as intended